### PR TITLE
fix: wrong logs init for substate

### DIFF
--- a/src/executor/stack.rs
+++ b/src/executor/stack.rs
@@ -84,7 +84,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 			config: self.config,
 			state: self.state.clone(),
 			deleted: self.deleted.clone(),
-			logs: self.logs.clone(),
+			logs: Vec::new(),
 			precompile: self.precompile,
 			is_static: is_static || self.is_static,
 			depth: match self.depth {


### PR DESCRIPTION
`substate`'s `logs` are merged by `Vec::append`.

So every time a `substate` is created, `logs` should be empty. Or else it may increase exponentially.
