### PR TITLE
Adds tracing logs to EVM execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4", default-features = false }
 evm-core = { version = "0.17", path = "core", default-features = false }
 evm-gasometer = { version = "0.17", path = "gasometer", default-features = false }
 evm-runtime = { version = "0.17", path = "runtime", default-features = false }
@@ -21,7 +21,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 [features]
 default = ["std"]
 with-serde = ["serde", "primitive-types/serde"]
-std = ["evm-core/std", "evm-gasometer/std", "evm-runtime/std", "sha3/std", "primitive-types/std", "serde/std"]
+std = ["evm-core/std", "evm-gasometer/std", "evm-runtime/std", "sha3/std", "primitive-types/std", "serde/std", "log/std"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
+log = "0.4"
 evm-core = { version = "0.17", path = "core", default-features = false }
 evm-gasometer = { version = "0.17", path = "gasometer", default-features = false }
 evm-runtime = { version = "0.17", path = "runtime", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4", default-features = false }
 primitive-types = { version = "0.7", default-features = false }
 
 [dev-dependencies]
@@ -17,4 +17,4 @@ hex = "0.4"
 
 [features]
 default = ["std"]
-std = ["primitive-types/std"]
+std = ["primitive-types/std", "log/std"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
+log = "0.4"
 primitive-types = { version = "0.7", default-features = false }
 
 [dev-dependencies]

--- a/core/src/eval/macros.rs
+++ b/core/src/eval/macros.rs
@@ -1,3 +1,7 @@
+macro_rules! trace_op {
+	($($arg:tt)*) => (log::trace!(target: "evm", "OpCode {}", format_args!($($arg)*)));
+}
+
 macro_rules! try_or_fail {
 	( $e:expr ) => {
 		match $e {
@@ -59,6 +63,7 @@ macro_rules! op1_u256_fn {
 			pop_u256!($machine, op1);
 			let ret = $op(op1);
 			push_u256!($machine, ret);
+			trace_op!("{} {}: {}", stringify!($op), op1, ret);
 
 			Control::Continue(1)
 		}
@@ -75,6 +80,7 @@ macro_rules! op2_u256_bool_ref {
 			} else {
 				U256::zero()
 			});
+			trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 			Control::Continue(1)
 		}
@@ -87,6 +93,7 @@ macro_rules! op2_u256 {
 			pop_u256!($machine, op1, op2);
 			let ret = op1.$op(op2);
 			push_u256!($machine, ret);
+			trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 			Control::Continue(1)
 		}
@@ -99,6 +106,7 @@ macro_rules! op2_u256_tuple {
 			pop_u256!($machine, op1, op2);
 			let (ret, ..) = op1.$op(op2);
 			push_u256!($machine, ret);
+			trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 			Control::Continue(1)
 		}
@@ -111,6 +119,7 @@ macro_rules! op2_u256_fn {
 			pop_u256!($machine, op1, op2);
 			let ret = $op(op1, op2);
 			push_u256!($machine, ret);
+			trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 			Control::Continue(1)
 		}
@@ -123,6 +132,7 @@ macro_rules! op3_u256_fn {
 			pop_u256!($machine, op1, op2, op3);
 			let ret = $op(op1, op2, op3);
 			push_u256!($machine, ret);
+			trace_op!("{} {}, {}, {}: {}", stringify!($op), op1, op2, op3, ret);
 
 			Control::Continue(1)
 		}

--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -5,12 +5,14 @@ use crate::{Machine, ExitError, ExitSucceed, ExitFatal, ExitRevert};
 
 pub fn codesize(state: &mut Machine) -> Control {
 	let size = U256::from(state.code.len());
+	trace_op!("CodeSize: {}", size);
 	push_u256!(state, size);
 	Control::Continue(1)
 }
 
 pub fn codecopy(state: &mut Machine) -> Control {
 	pop_u256!(state, memory_offset, code_offset, len);
+	trace_op!("CodeCopy: {}", len);
 
 	try_or_fail!(state.memory.resize_offset(memory_offset, len));
 	match state.memory.copy_large(memory_offset, code_offset, len, &state.code) {
@@ -21,6 +23,7 @@ pub fn codecopy(state: &mut Machine) -> Control {
 
 pub fn calldataload(state: &mut Machine) -> Control {
 	pop_u256!(state, index);
+	trace_op!("CallDataLoad: {}", index);
 
 	let mut load = [0u8; 32];
 	for i in 0..32 {
@@ -39,12 +42,15 @@ pub fn calldataload(state: &mut Machine) -> Control {
 }
 
 pub fn calldatasize(state: &mut Machine) -> Control {
-	push_u256!(state, U256::from(state.data.len()));
+	let len = U256::from(state.data.len());
+	trace_op!("CallDataSize: {}", len);
+	push_u256!(state, len);
 	Control::Continue(1)
 }
 
 pub fn calldatacopy(state: &mut Machine) -> Control {
 	pop_u256!(state, memory_offset, data_offset, len);
+	trace_op!("CallDataCopy: {}", len);
 
 	try_or_fail!(state.memory.resize_offset(memory_offset, len));
 	if len == U256::zero() {
@@ -58,12 +64,14 @@ pub fn calldatacopy(state: &mut Machine) -> Control {
 }
 
 pub fn pop(state: &mut Machine) -> Control {
-	pop!(state, _any);
+	pop!(state, val);
+	trace_op!("Pop  [@{}]: {}", state.stack.len(), val);
 	Control::Continue(1)
 }
 
 pub fn mload(state: &mut Machine) -> Control {
 	pop_u256!(state, index);
+	trace_op!("MLoad: {}", index);
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
 	let index = as_usize_or_fail!(index);
 	let value = H256::from_slice(&state.memory.get(index, 32)[..]);
@@ -74,6 +82,7 @@ pub fn mload(state: &mut Machine) -> Control {
 pub fn mstore(state: &mut Machine) -> Control {
 	pop_u256!(state, index);
 	pop!(state, value);
+	trace_op!("MStore: {}, {}", index, value);
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
 	let index = as_usize_or_fail!(index);
 	match state.memory.set(index, &value[..], Some(32)) {
@@ -84,6 +93,7 @@ pub fn mstore(state: &mut Machine) -> Control {
 
 pub fn mstore8(state: &mut Machine) -> Control {
 	pop_u256!(state, index, value);
+	trace_op!("MStore8: {}, {}", index, value);
 	try_or_fail!(state.memory.resize_offset(index, U256::one()));
 	let index = as_usize_or_fail!(index);
 	let value = (value.low_u32() & 0xff) as u8;
@@ -96,6 +106,7 @@ pub fn mstore8(state: &mut Machine) -> Control {
 pub fn jump(state: &mut Machine) -> Control {
 	pop_u256!(state, dest);
 	let dest = as_usize_or_fail!(dest, ExitError::InvalidJump);
+	trace_op!("Jump: {}", dest);
 
 	if state.valids.is_valid(dest) {
 		Control::Jump(dest)
@@ -109,30 +120,36 @@ pub fn jumpi(state: &mut Machine) -> Control {
 	let dest = as_usize_or_fail!(dest, ExitError::InvalidJump);
 
 	if value != U256::zero() {
+		trace_op!("JumpI: {}", dest);
 		if state.valids.is_valid(dest) {
 			Control::Jump(dest)
 		} else {
 			Control::Exit(ExitError::InvalidJump.into())
 		}
 	} else {
+		trace_op!("JumpI: skipped");
 		Control::Continue(1)
 	}
 }
 
 pub fn pc(state: &mut Machine, position: usize) -> Control {
+	trace_op!("PC");
 	push_u256!(state, U256::from(position));
 	Control::Continue(1)
 }
 
 pub fn msize(state: &mut Machine) -> Control {
+	trace_op!("MSize");
 	push_u256!(state, U256::from(state.memory.effective_len()));
 	Control::Continue(1)
 }
 
 pub fn push(state: &mut Machine, n: usize, position: usize) -> Control {
 	let end = min(position + 1 + n, state.code.len());
+	let val = U256::from(&state.code[(position + 1)..end]);
 
-	push_u256!(state, U256::from(&state.code[(position + 1)..end]));
+	push_u256!(state, val);
+	trace_op!("Push [@{}]: {}", state.stack.len() - 1, val);
 	Control::Continue(1 + n)
 }
 
@@ -141,6 +158,7 @@ pub fn dup(state: &mut Machine, n: usize) -> Control {
 		Ok(value) => value,
 		Err(e) => return Control::Exit(e.into()),
 	};
+	trace_op!("Dup{} [@{}]: {}", n, state.stack.len(), value);
 	push!(state, value);
 	Control::Continue(1)
 }
@@ -162,10 +180,12 @@ pub fn swap(state: &mut Machine, n: usize) -> Control {
 		Ok(()) => (),
 		Err(e) => return Control::Exit(e.into()),
 	}
+	trace_op!("Swap [@0:@{}]: {}, {}", n, val1, val2);
 	Control::Continue(1)
 }
 
 pub fn ret(state: &mut Machine) -> Control {
+	trace_op!("Return");
 	pop_u256!(state, start, len);
 	try_or_fail!(state.memory.resize_offset(start, len));
 	state.return_range = start..(start + len);
@@ -173,6 +193,7 @@ pub fn ret(state: &mut Machine) -> Control {
 }
 
 pub fn revert(state: &mut Machine) -> Control {
+	trace_op!("Revert");
 	pop_u256!(state, start, len);
 	try_or_fail!(state.memory.resize_offset(start, len));
 	state.return_range = start..(start + len);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -145,6 +145,7 @@ impl Machine {
 				}
 			},
 			Some(Err(external)) => {
+				log::trace!(target: "evm", "OpCode External: {:?}", external);
 				self.position = Ok(position + 1);
 				Err(Capture::Trap(external))
 			},

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -23,6 +23,11 @@ impl Stack {
 		self.limit
 	}
 
+	/// Stack length.
+	pub fn len(&self) -> usize {
+		self.data.len()
+	}
+
 	/// Pop a value from the stack. If the stack is already empty, returns the
 	/// `StackUnderflow` error.
 	pub fn pop(&mut self) -> Result<H256, ExitError> {

--- a/src/executor/stack.rs
+++ b/src/executor/stack.rs
@@ -445,6 +445,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 		);
 
 		let reason = substate.execute(&mut runtime);
+		log::debug!(target: "evm", "Create execution using address {}: {:?}", address, reason);
 
 		match reason {
 			ExitReason::Succeed(s) => {
@@ -572,6 +573,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 		);
 
 		let reason = substate.execute(&mut runtime);
+		log::debug!(target: "evm", "Call execution using address {}: {:?}", code_address, reason);
 
 		match reason {
 			ExitReason::Succeed(s) => {


### PR DESCRIPTION
It adds logs to OpCodes when getting executed (including values) at "trace" level with target "evm"

Ex of ERC20 creation:
```
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@0]: 128
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@1]: 64
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode MStore: 64, 0x0000…0080
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode External: CallValue
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Dup1 [@1]: 0x0000…0000
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode self::bitwise::iszero 0: 1
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@2]: 16
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode JumpI: 16
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Pop  [@0]: 0x0000…0000
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@0]: 36
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode External: Caller
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@2]: 156000
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@3]: 41
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@4]: 32
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode self::bitwise::shl 32, 41: 176093659136
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@4]: 32
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode self::bitwise::shr 32, 176093659136: 41
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Jump: 41
2020-09-05 15:38:36.134 tokio-blocking-driver TRACE evm  OpCode Push [@3]: 0
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode Push [@4]: 1461501637330902918203684832716283019655932542975
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode bitand 1461501637330902918203684832716283019655932542975, 0: 0
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode Dup3 [@4]: 0x0000…c91b
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode Push [@5]: 1461501637330902918203684832716283019655932542975
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode bitand 1461501637330902918203684832716283019655932542975, 615861309395982062196639569664127879240801241371: 615861309395982062196639569664127879240801241371
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode eq 615861309395982062196639569664127879240801241371, 0: false
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode self::bitwise::iszero 0: 1
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode Push [@4]: 204
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode JumpI: 204
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode Push [@3]: 229
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode Dup2 [@4]: 0x0000…6160
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode Push [@5]: 2
2020-09-05 15:38:36.135 tokio-blocking-driver TRACE evm  OpCode External: SLoad
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Push [@6]: 492
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 32
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode self::bitwise::shl 32, 492: 2113123909632
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 3196
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode bitor 3196, 2113123909632: 2113123912828
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…0c7c, 0x0000…0000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@2]: 0x0000…0000, 0x0000…6160
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…6160, 0x0000…0c7c
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 32
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode self::bitwise::shr 32, 2113123912828: 492
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Jump: 492
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Push [@6]: 0
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Dup1 [@7]: 0x0000…0000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Dup3 [@8]: 0x0000…6160
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Dup5 [@9]: 0x0000…0000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode overflowing_add 0, 156000: 156000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…6160, 0x0000…0000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Pop  [@8]: 0x0000…0000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Dup4 [@8]: 0x0000…0000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Dup2 [@9]: 0x0000…6160
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode lt 156000, 0: false
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode self::bitwise::iszero 0: 1
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Push [@9]: 618
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode JumpI: 618
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Dup1 [@8]: 0x0000…6160
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@2]: 0x0000…6160, 0x0000…0000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Pop  [@8]: 0x0000…0000
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Pop  [@7]: 0x0000…6160
2020-09-05 15:38:36.136 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@3]: 0x0000…6160, 0x0000…00e5
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@2]: 0x0000…00e5, 0x0000…0000
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Pop  [@6]: 0x0000…0000
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Pop  [@5]: 0x0000…6160
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Jump: 229
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Push [@4]: 2
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Dup2 [@5]: 0x0000…6160
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…6160, 0x0000…0002
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode External: SStore
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Pop  [@3]: 0x0000…6160
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Push [@3]: 320
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Dup2 [@4]: 0x0000…6160
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Push [@5]: 0
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Dup1 [@6]: 0x0000…0000
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Dup6 [@7]: 0x0000…c91b
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Push [@8]: 1461501637330902918203684832716283019655932542975
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode bitand 1461501637330902918203684832716283019655932542975, 615861309395982062196639569664127879240801241371: 615861309395982062196639569664127879240801241371
2020-09-05 15:38:36.137 tokio-blocking-driver TRACE evm  OpCode Push [@8]: 1461501637330902918203684832716283019655932542975
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode bitand 1461501637330902918203684832716283019655932542975, 615861309395982062196639569664127879240801241371: 615861309395982062196639569664127879240801241371
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Dup2 [@8]: 0x0000…0000
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode MStore: 0, 0x0000…c91b
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 32
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode overflowing_add 32, 0: 32
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…0020, 0x0000…0000
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Dup2 [@7]: 0x0000…0020
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode MStore: 32, 0x0000…0000
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Push [@6]: 32
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode overflowing_add 32, 32: 64
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Push [@6]: 0
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode External: Sha3
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode External: SLoad
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Push [@6]: 492
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 32
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode self::bitwise::shl 32, 492: 2113123909632
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 3196
2020-09-05 15:38:36.138 tokio-blocking-driver TRACE evm  OpCode bitor 3196, 2113123909632: 2113123912828
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…0c7c, 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@2]: 0x0000…0000, 0x0000…6160
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…6160, 0x0000…0c7c
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 32
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode self::bitwise::shr 32, 2113123912828: 492
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Jump: 492
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Push [@6]: 0
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Dup1 [@7]: 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Dup3 [@8]: 0x0000…6160
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Dup5 [@9]: 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode overflowing_add 0, 156000: 156000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…6160, 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Pop  [@8]: 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Dup4 [@8]: 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Dup2 [@9]: 0x0000…6160
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode lt 156000, 0: false
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode self::bitwise::iszero 0: 1
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Push [@9]: 618
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode JumpI: 618
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Dup1 [@8]: 0x0000…6160
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@2]: 0x0000…6160, 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Pop  [@8]: 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Pop  [@7]: 0x0000…6160
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@3]: 0x0000…6160, 0x0000…0140
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@2]: 0x0000…0140, 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Pop  [@6]: 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Pop  [@5]: 0x0000…6160
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Jump: 320
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Push [@4]: 0
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Dup1 [@5]: 0x0000…0000
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Dup5 [@6]: 0x0000…c91b
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 1461501637330902918203684832716283019655932542975
2020-09-05 15:38:36.139 tokio-blocking-driver TRACE evm  OpCode bitand 1461501637330902918203684832716283019655932542975, 615861309395982062196639569664127879240801241371: 615861309395982062196639569664127879240801241371
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 1461501637330902918203684832716283019655932542975
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode bitand 1461501637330902918203684832716283019655932542975, 615861309395982062196639569664127879240801241371: 615861309395982062196639569664127879240801241371
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode Dup2 [@7]: 0x0000…0000
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode MStore: 0, 0x0000…c91b
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode Push [@6]: 32
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode overflowing_add 32, 0: 32
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…0020, 0x0000…0000
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode Dup2 [@6]: 0x0000…0020
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode MStore: 32, 0x0000…0000
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode Push [@5]: 32
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode overflowing_add 32, 32: 64
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode Push [@5]: 0
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode External: Sha3
2020-09-05 15:38:36.140 tokio-blocking-driver TRACE evm  OpCode Dup2 [@5]: 0x0000…6160
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…6160, 0x7204…69a7
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode External: SStore
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode Pop  [@3]: 0x0000…6160
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode Dup2 [@3]: 0x0000…c91b
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode Push [@4]: 1461501637330902918203684832716283019655932542975
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode bitand 1461501637330902918203684832716283019655932542975, 615861309395982062196639569664127879240801241371: 615861309395982062196639569664127879240801241371
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode Push [@4]: 0
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode Push [@5]: 1461501637330902918203684832716283019655932542975
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode bitand 1461501637330902918203684832716283019655932542975, 0: 0
2020-09-05 15:38:36.141 tokio-blocking-driver TRACE evm  OpCode Push [@5]: 100389287136786176327247604509743168900146139575972864366142685224231313322991
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Dup4 [@6]: 0x0000…6160
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 64
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode MLoad: 64
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Dup1 [@8]: 0x0000…0080
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Dup3 [@9]: 0x0000…6160
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Dup2 [@10]: 0x0000…0080
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode MStore: 128, 0x0000…6160
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Push [@9]: 32
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode overflowing_add 32, 128: 160
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@2]: 0x0000…00a0, 0x0000…6160
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Pop  [@8]: 0x0000…6160
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Pop  [@7]: 0x0000…0080
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Push [@7]: 64
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode MLoad: 64
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Dup1 [@8]: 0x0000…0080
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@2]: 0x0000…0080, 0x0000…00a0
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode overflowing_sub 160, 128: 32
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Swap [@0:@1]: 0x0000…0020, 0x0000…0080
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode External: Log(3)
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Pop  [@2]: 0x0000…6160
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Pop  [@1]: 0x0000…c91b
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Jump: 36
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Push [@0]: 628
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Jump: 628
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Push [@0]: 3642
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Dup1 [@1]: 0x0000…0e3a
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Push [@2]: 643
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode Push [@3]: 0
2020-09-05 15:38:36.142 tokio-blocking-driver TRACE evm  OpCode CodeCopy: 3642
2020-09-05 15:38:36.143 tokio-blocking-driver TRACE evm  OpCode Push [@1]: 0
2020-09-05 15:38:36.143 tokio-blocking-driver TRACE evm  OpCode Return
2020-09-05 15:38:36.143 tokio-blocking-driver DEBUG evm  Create execution using address 0xc2bf…084a: Succeed(Returned)

```