### PR TITLE
Bump primitive-types versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rlp = { version = "0.5", default-features = false }
 primitive-types = { version = "0.8", default-features = false, features = ["rlp"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"], optional = true }
-ethereum = { version = ">=0.4, <0.6", git = "https://github.com/rust-blockchain/ethereum.git", branch = "vorot93/bump-deps", default-features = false }
+ethereum = { version = ">=0.4, <0.6", git = "https://github.com/rust-blockchain/ethereum.git", branch = "master", default-features = false }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ evm-core = { version = "0.20", path = "core", default-features = false }
 evm-gasometer = { version = "0.20", path = "gasometer", default-features = false }
 evm-runtime = { version = "0.20", path = "runtime", default-features = false }
 sha3 = { version = "0.8", default-features = false }
-rlp = { version = "0.4", default-features = false }
-primitive-types = { version = "0.7", default-features = false, features = ["rlp"] }
+rlp = { version = "0.5", default-features = false }
+primitive-types = { version = "0.8", default-features = false, features = ["rlp"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"], optional = true }
-ethereum = { version = ">=0.4, <0.6", default-features = false }
+ethereum = { version = ">=0.4, <0.6", git = "https://github.com/rust-blockchain/ethereum.git", branch = "vorot93/bump-deps", default-features = false }
 
 [features]
 default = ["std"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.7", default-features = false }
+primitive-types = { version = "0.8", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.7", default-features = false }
+primitive-types = { version = "0.8", default-features = false }
 evm-core = { version = "0.20", path = "../core", default-features = false }
 evm-runtime = { version = "0.20", path = "../runtime", default-features = false }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 evm-core = { version = "0.20", path = "../core", default-features = false }
-primitive-types = { version = "0.7", default-features = false }
+primitive-types = { version = "0.8", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 
 [features]


### PR DESCRIPTION
This PR is not ready for merging, because it still relies on the `vorot93/bump-deps` branch of EVM, which is waiting at this PR: https://github.com/rust-blockchain/ethereum/pull/7

Once the above PR goes in, we can set that dependency to a published version and this PR will be ready to go.