### PR TITLE
Bump parity-scale-codec and primitive-types versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ evm-gasometer = { version = "0.23", path = "gasometer", default-features = false
 evm-runtime = { version = "0.23", path = "runtime", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 rlp = { version = "0.5", default-features = false }
-primitive-types = { version = "0.8", default-features = false, features = ["rlp"] }
+primitive-types = { version = "0.9", default-features = false, features = ["rlp"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
-codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"], optional = true }
+codec = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"], optional = true }
 ethereum = { version = "0.6", default-features = false }
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.8", default-features = false }
-codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
+primitive-types = { version = "0.9", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.8", default-features = false }
+primitive-types = { version = "0.9", default-features = false }
 evm-core = { version = "0.23", path = "../core", default-features = false }
 evm-runtime = { version = "0.23", path = "../runtime", default-features = false }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 evm-core = { version = "0.23", path = "../core", default-features = false }
-primitive-types = { version = "0.8", default-features = false }
+primitive-types = { version = "0.9", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 
 [features]


### PR DESCRIPTION
This bumps `parity-scale-codec` and `primitive-types` versions.

This is needed so that `frontier` can have a consistent dependency on `parity-scale-codec`.