### PR TITLE
exit execution if an error occurred

### DIFF
--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -275,9 +275,9 @@ pub fn create<H: Handler>(
 					push!(runtime, H256::default());
 					Control::Continue
 				},
-				ExitReason::Error(_) => {
+				ExitReason::Error(e) => {
 					push!(runtime, H256::default());
-					Control::Continue
+					Control::Exit(e.into())
 				},
 				ExitReason::Fatal(e) => {
 					push!(runtime, H256::default());
@@ -400,10 +400,10 @@ pub fn call<'config, H: Handler>(
 
 					Control::Continue
 				},
-				ExitReason::Error(_) => {
+				ExitReason::Error(e) => {
 					push_u256!(runtime, U256::zero());
 
-					Control::Continue
+					Control::Exit(e.into())
 				},
 				ExitReason::Fatal(e) => {
 					push_u256!(runtime, U256::zero());


### PR DESCRIPTION
@sorpaas Currently if any substrate error occur it will be ignored and execution will continue to revert without any message. I'm not sure if there's any specific reason to that. Hopefully this will fix it.