### PR TITLE
Hook into the EVM execution loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ default = ["std"]
 with-codec = ["codec", "evm-core/with-codec", "primitive-types/codec", "ethereum/with-codec"]
 with-serde = ["serde", "evm-core/with-serde", "primitive-types/serde", "ethereum/with-serde"]
 std = ["evm-core/std", "evm-gasometer/std", "evm-runtime/std", "sha3/std", "primitive-types/std", "serde/std", "codec/std", "log/std", "ethereum/std"]
+hook = []
 
 [workspace]
 members = [

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,6 +47,10 @@ pub struct Machine {
 }
 
 impl Machine {
+	/// Reference to the program data.
+	pub fn data(&self) -> &[u8] { &self.data }	
+	/// Reference to the program code.
+	pub fn code(&self) -> &[u8] { &self.code }
 	/// Reference of machine stack.
 	pub fn stack(&self) -> &Stack { &self.stack }
 	/// Mutable reference of machine stack.

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -5,4 +5,4 @@
 
 mod stack;
 
-pub use self::stack::{StackExecutor, MemoryStackState, StackState, StackSubstateMetadata, StackExitKind, Hook};
+pub use self::stack::{StackExecutor, MemoryStackState, StackState, StackSubstateMetadata, StackExitKind, Hook, HookSite};

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -5,4 +5,4 @@
 
 mod stack;
 
-pub use self::stack::{StackExecutor, MemoryStackState, StackState, StackSubstateMetadata};
+pub use self::stack::{StackExecutor, MemoryStackState, StackState, StackSubstateMetadata, Hook};


### PR DESCRIPTION
Adds a `Hook` trait defining functions to inspect the state of the EVM :
- before and after each step (opcode execution)
- before and after each context (entering and leaving a contract scope)

It is set using the `set_hook(&mut self, mut hook: Option<H>) -> Option<H>` on a `StackExecutor`, which will return the previous optional hook. Having ownership of the hook while executing the bytecode avoids mutability issues, and it can be retrieved after for inspection.

This can be used for multiple purposes :
- Implement RPC calls such as `debug_traceTransaction`
- Implement a more fine-tuned gas to weight mapping in Frontier as in [this experiment](https://github.com/PureStake/frontier/blob/jeremy-weightometer-with-hook/frame/evm/src/runner/stack.rs#L49).

`Hook` is implemented for `()` which is the default type used by `StackExecutor<'config, S, H = ()>` to avoid breaking changes.
No hook is attached by default, adding only a `self.hook.is_some()` check overhead once per context.