### PR TITLE
Accessors to enable stepping outside the evm

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -55,6 +55,8 @@ impl Machine {
 	pub fn memory(&self) -> &Memory { &self.memory }
 	/// Mutable reference of machine memory.
 	pub fn memory_mut(&mut self) -> &mut Memory { &mut self.memory }
+	/// Return a reference of the program counter.
+	pub fn position(&self) -> &Result<usize, ExitReason> { &self.position }
 
 	/// Create a new machine with given code and data.
 	pub fn new(

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -42,6 +42,11 @@ impl Memory {
 		self.len() == 0
 	}
 
+	/// Return the full memory.
+	pub fn data(&self) -> &Vec<u8> {
+		&self.data
+	}
+
 	/// Resize the memory, making it cover the memory region of `offset..(offset
 	/// + len)`, with 32 bytes as the step. If the length is zero, this function
 	/// does nothing.

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -31,6 +31,12 @@ impl Stack {
 	}
 
 	#[inline]
+	/// Stack data.
+	pub fn data(&self) -> &Vec<H256> {
+		&self.data
+	}
+
+	#[inline]
 	/// Pop a value from the stack. If the stack is already empty, returns the
 	/// `StackUnderflow` error.
 	pub fn pop(&mut self) -> Result<H256, ExitError> {

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -590,7 +590,7 @@ impl<'config> Inner<'config> {
 	}
 
 	/// Returns the gas cost numerical value.
-	pub fn gas_cost(
+	fn gas_cost(
 		&self,
 		cost: GasCost,
 		gas: u64,

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -51,6 +51,14 @@ impl<'config> Gasometer<'config> {
 	}
 
 	#[inline]
+	/// Reference of the inner gasometer data.
+	pub fn inner(
+		&self
+	) -> Result<&Inner<'config>, ExitError> {
+		self.inner.as_ref().map_err(|e| e.clone())
+	}
+
+	#[inline]
 	fn inner_mut(
 		&mut self
 	) -> Result<&mut Inner<'config>, ExitError> {
@@ -524,8 +532,9 @@ pub fn dynamic_opcode_cost<H: Handler>(
 	Ok((gas_cost, memory_cost))
 }
 
+/// Holds the gas consumption for a Gasometer instance.
 #[derive(Clone)]
-struct Inner<'config> {
+pub struct Inner<'config> {
 	memory_gas: u64,
 	used_gas: u64,
 	refunded_gas: i64,
@@ -575,7 +584,8 @@ impl<'config> Inner<'config> {
 		}
 	}
 
-	fn gas_cost(
+	/// Returns the gas cost numerical value.
+	pub fn gas_cost(
 		&self,
 		cost: GasCost,
 		gas: u64,

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -51,11 +51,16 @@ impl<'config> Gasometer<'config> {
 	}
 
 	#[inline]
-	/// Reference of the inner gasometer data.
-	pub fn inner(
-		&self
-	) -> Result<&Inner<'config>, ExitError> {
-		self.inner.as_ref().map_err(|e| e.clone())
+	/// Returns the numerical gas cost value.
+	pub fn gas_cost(
+		&self,
+		cost: GasCost,
+		gas: u64,
+	) -> Result<u64, ExitError>  {
+		match self.inner.as_ref() {
+			Ok(inner) => inner.gas_cost(cost, gas),
+			Err(e) => Err(e.clone())
+		}
 	}
 
 	#[inline]
@@ -534,7 +539,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 
 /// Holds the gas consumption for a Gasometer instance.
 #[derive(Clone)]
-pub struct Inner<'config> {
+struct Inner<'config> {
 	memory_gas: u64,
 	used_gas: u64,
 	refunded_gas: i64,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -106,6 +106,11 @@ impl<'config> Runtime<'config> {
 		&self.machine
 	}
 
+	/// Get a reference to the execution context.
+	pub fn context(&self) -> &Context {
+		&self.context
+	}
+
 	/// Step the runtime.
 	pub fn step<'a, H: Handler>(
 		&'a mut self,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -5,4 +5,4 @@
 
 mod stack;
 
-pub use self::stack::{StackExecutor, MemoryStackState, StackState, StackSubstateMetadata};
+pub use self::stack::{StackExecutor, MemoryStackState, StackState, StackSubstateMetadata, StackExitKind};

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -61,6 +61,22 @@ impl<'config> StackSubstateMetadata<'config> {
 			},
 		}
 	}
+
+	pub fn gasometer(&self) -> &Gasometer<'config> {
+		&self.gasometer
+	}
+
+	pub fn gasometer_mut(&mut self) -> &mut Gasometer<'config> {
+		&mut self.gasometer
+	}
+
+	pub fn is_static(&self) -> bool {
+		self.is_static
+	}
+
+	pub fn depth(&self) -> Option<usize> {
+		self.depth
+	}
 }
 
 /// Stack-based executor.
@@ -86,6 +102,13 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		config: &'config Config,
 	) -> Self {
 		Self::new_with_precompile(state, config, no_precompile)
+	}
+
+	/// Return a reference of the Config.
+	pub fn config(
+		&self
+	) -> &'config Config {
+		self.config
 	}
 
 	/// Create a new stack-based executor with given precompiles.


### PR DESCRIPTION
Tracing modules like Geth's [debug](https://geth.ethereum.org/docs/rpc/ns-debug) or Open Ethereum's [trace](https://openethereum.github.io/JSONRPC-trace-module) require stepping the EVM - the same way that the evm Runtime does -  while capturing and storing the intermediate state between steps. This is not currently built in the EVM, but possible outside of it with the help of some accessor functions to get data that currently lives in private fields:

- Program Counter.
- Memory.
- Stack.
- Gasometer data.
- Execution Context.
- Depth.
- Access to wheter a inner call is static or not.

Additionally:

- A public re-export of the `StackExitKind` type.