### PR TITLE
StackExecutor inner refactor

### DIFF
--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -161,16 +161,21 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			Err(e) => return e.into(),
 		}
 
-		match self.create_inner(
+		match self.create_prepare(
 			caller,
 			CreateScheme::Legacy { caller },
 			value,
-			init_code,
 			Some(gas_limit),
-			false,
+			false
 		) {
-			Capture::Exit((s, _, _)) => s,
-			Capture::Trap(_) => unreachable!(),
+			Ok((context, address)) => {
+				let (reason, return_value) = self.create_execute(address, init_code, context);
+				match self.create_capture(address, reason, return_value) {
+					Capture::Exit((s, _, _)) => s,
+					Capture::Trap(_) => unreachable!(),
+				}
+			},
+			Err(e) => return e.into()
 		}
 	}
 
@@ -190,16 +195,21 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		}
 		let code_hash = H256::from_slice(Keccak256::digest(&init_code).as_slice());
 
-		match self.create_inner(
+		match self.create_prepare(
 			caller,
 			CreateScheme::Create2 { caller, code_hash, salt },
 			value,
-			init_code,
 			Some(gas_limit),
-			false,
+			false
 		) {
-			Capture::Exit((s, _, _)) => s,
-			Capture::Trap(_) => unreachable!(),
+			Ok((context, address)) => {
+				let (reason, return_value) = self.create_execute(address, init_code, context);
+				match self.create_capture(address, reason, return_value) {
+					Capture::Exit((s, _, _)) => s,
+					Capture::Trap(_) => unreachable!(),
+				}
+			},
+			Err(e) => return e.into()
 		}
 	}
 
@@ -283,20 +293,19 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		}
 	}
 
-	fn create_inner(
+	fn create_prepare(
 		&mut self,
 		caller: H160,
 		scheme: CreateScheme,
 		value: U256,
-		init_code: Vec<u8>,
 		target_gas: Option<u64>,
 		take_l64: bool,
-	) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Infallible> {
+	) -> Result<(Context, H160), ExitError> {
 		macro_rules! try_or_fail {
 			( $e:expr ) => {
 				match $e {
 					Ok(v) => v,
-					Err(e) => return Capture::Exit((e.into(), None, Vec::new())),
+					Err(e) => return Err(e),
 				}
 			}
 		}
@@ -307,12 +316,12 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 
 		if let Some(depth) = self.state.metadata().depth {
 			if depth > self.config.call_stack_limit {
-				return Capture::Exit((ExitError::CallTooDeep.into(), None, Vec::new()))
+				return Err(ExitError::CallTooDeep)
 			}
 		}
 
 		if self.balance(caller) < value {
-			return Capture::Exit((ExitError::OutOfFund.into(), None, Vec::new()))
+			return Err(ExitError::OutOfFund)
 		}
 
 		let after_gas = if take_l64 && self.config.call_l64_after_gas {
@@ -343,12 +352,12 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		{
 			if self.code_size(address) != U256::zero() {
 				let _ = self.exit_substate(StackExitKind::Failed);
-				return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()))
+				return Err(ExitError::CreateCollision)
 			}
 
 			if self.nonce(address) > U256::zero() {
 				let _ = self.exit_substate(StackExitKind::Failed);
-				return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()))
+				return Err(ExitError::CreateCollision)
 			}
 
 			self.state.reset_storage(address);
@@ -368,7 +377,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			Ok(()) => (),
 			Err(e) => {
 				let _ = self.exit_substate(StackExitKind::Reverted);
-				return Capture::Exit((ExitReason::Error(e), None, Vec::new()))
+				return Err(e)
 			},
 		}
 
@@ -376,33 +385,51 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			self.state.inc_nonce(address);
 		}
 
+		Ok((context, address))
+	}
+
+	fn create_execute(
+		&mut self,
+		address: H160,
+		init_code: Vec<u8>,
+		context: Context,
+	) -> (ExitReason, Vec<u8>) {
 		let mut runtime = Runtime::new(
 			Rc::new(init_code),
 			Rc::new(Vec::new()),
 			context,
 			self.config,
 		);
-
 		let reason = self.execute(&mut runtime);
 		log::debug!(target: "evm", "Create execution using address {}: {:?}", address, reason);
+		(reason, runtime.machine().return_value())
+	}
 
+	fn create_capture(
+		&mut self,
+		address: H160,
+		reason: ExitReason,
+		return_value: Vec<u8>
+	) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Infallible> {
 		match reason {
 			ExitReason::Succeed(s) => {
-				let out = runtime.machine().return_value();
-
+				
 				if let Some(limit) = self.config.create_contract_limit {
-					if out.len() > limit {
+					if return_value.len() > limit {
 						self.state.metadata_mut().gasometer.fail();
 						let _ = self.exit_substate(StackExitKind::Failed);
 						return Capture::Exit((ExitError::CreateContractLimit.into(), None, Vec::new()))
 					}
 				}
 
-				match self.state.metadata_mut().gasometer.record_deposit(out.len()) {
+				match self.state.metadata_mut().gasometer.record_deposit(return_value.len()) {
 					Ok(()) => {
 						let e = self.exit_substate(StackExitKind::Succeeded);
-						self.state.set_code(address, out);
-						try_or_fail!(e);
+						self.state.set_code(address, return_value);
+						match e {
+							Ok(v) => v,
+							Err(e) => return Capture::Exit((e.into(), None, Vec::new())),
+						}
 						Capture::Exit((ExitReason::Succeed(s), Some(address), Vec::new()))
 					},
 					Err(e) => {
@@ -418,7 +445,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			},
 			ExitReason::Revert(e) => {
 				let _ = self.exit_substate(StackExitKind::Reverted);
-				Capture::Exit((ExitReason::Revert(e), None, runtime.machine().return_value()))
+				Capture::Exit((ExitReason::Revert(e), None, return_value))
 			},
 			ExitReason::Fatal(e) => {
 				self.state.metadata_mut().gasometer.fail();
@@ -638,7 +665,13 @@ impl<'config, S: StackState<'config>> Handler for StackExecutor<'config, S> {
 		init_code: Vec<u8>,
 		target_gas: Option<u64>,
 	) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Self::CreateInterrupt> {
-		self.create_inner(caller, scheme, value, init_code, target_gas, true)
+		match self.create_prepare(caller, scheme, value, target_gas, true) {
+			Ok((context, address)) => {
+				let (reason, return_value) = self.create_execute(address, init_code, context);
+				return self.create_capture(address, reason, return_value);
+			},
+			Err(e) => return Capture::Exit((e.into(), None, Vec::new()))
+		}
 	}
 
 	fn call(

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -305,7 +305,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		}
 	}
 
-	fn create_prepare(
+	pub fn create_prepare(
 		&mut self,
 		caller: H160,
 		scheme: CreateScheme,
@@ -417,7 +417,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		(reason, runtime.machine().return_value())
 	}
 
-	fn create_capture(
+	pub fn create_capture(
 		&mut self,
 		address: H160,
 		reason: ExitReason,
@@ -467,7 +467,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		}
 	}
 
-	fn call_prepare(
+	pub fn call_prepare(
 		&mut self,
 		code_address: H160,
 		transfer: Option<Transfer>,
@@ -573,7 +573,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		(reason, runtime.machine().return_value())
 	}
 
-	fn call_capture(
+	pub fn call_capture(
 		&mut self,
 		reason: ExitReason,
 		return_value: Vec<u8>


### PR DESCRIPTION
Draft, for @sorpaas review.

### Motivation

Current design provides one entry point per context type - `transact_create`, `transact_create2`, `transact_call` - that trigger the recursive execution of all opcodes in the `Runtime` to finally capture the `ExitReason`.

This works but does not allow stepping the EVM. To enable tracing, we need some sort of interface that allows capturing the state between opcode executions. There is currently another proposal from @nanocryk (imo **better one**, the only one until now that is purely readonly), this is just an alternative approach so we can evaluate the pros and cons of each one.

This PR proposes decoupling `call_inner` and `create_inner` in 2 public (_prepare_, _capture_) and 1 private (_execute_) methods.

### Performance penalty

Overhead of two additional function calls per call stack.

### Visibility concerns

This approach modifies the public Api, and there is no guard to guarantee that for example only `call_prepare` is called, with no subsequent calls to `call_execute` and `call_capture` are made.

### Changes

_[pub]_ **call_prepare, create_prepare**

The initial gasometer corrections, balance checks, nonce handling, etc

_[priv]_ **call_execute, create_execute**

Create Runtime instance and trigger the recursive opcode execution.

_[pub]_ **call_capture, create_capture**

Captures the ExitReason.

