### PR TITLE
Don't ignore gasometer's record_cost() error

### DIFF
--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -526,7 +526,9 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		if let Some(ret) = (self.precompile)(code_address, &input, Some(gas_limit), &context) {
 			return match ret {
 				Ok((s, out, cost)) => {
-					let _ = self.state.metadata_mut().gasometer.record_cost(cost);
+					try_or_fail!(
+						self.state.metadata_mut().gasometer.record_cost(cost)
+					);
 					let _ = self.exit_substate(StackExitKind::Succeeded);
 					Capture::Exit((ExitReason::Succeed(s), out))
 				},


### PR DESCRIPTION
This fixes a problem where a precompile that returns gas exceeding the remaining gas is ignored. Instead of getting an OOG error, no gas is recorded -- effectively the precompile invocation is a freebie!