### PR TITLE
Pass state to precompiles

### DIFF
--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -91,7 +91,7 @@ pub struct PrecompileOutput {
 ///  * Address
 ///  * Input
 ///  * Context
-///	 * State
+///  * State
 ///  * Is static
 type PrecompileFn<S> = fn(H160, &[u8], Option<u64>, &Context, &mut S, bool) -> Option<Result<PrecompileOutput, ExitError>>;
 

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -107,7 +107,7 @@ fn no_precompile<S>(
 	_input: &[u8],
 	_target_gas: Option<u64>,
 	_context: &Context,
-    _state: &mut S,
+	_state: &mut S,
 	_is_static: bool,
 ) -> Option<Result<PrecompileOutput, ExitError>> {
 	None


### PR DESCRIPTION
Let precompiles have access to the state, and be aware whether the they were invoked in a static call or not.

We need this for [Aurora](https://github.com/aurora-is-near/aurora-engine/) since some precompiles trigger some behaviour in NEAR blockchain that needs to be tracked. The current interface of the state is used, to revert this behaviour in case the function call inside the EVM is also reverted.