### PR TITLE
Update minimum version of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ evm-gasometer = { version = "0.30", path = "gasometer", default-features = false
 evm-runtime = { version = "0.30", path = "runtime", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 rlp = { version = "0.5", default-features = false }
-primitive-types = { version = "0.10", default-features = false, features = ["rlp"] }
+primitive-types = { version = "~0.9", default-features = false, features = ["rlp"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"], optional = true }
-ethereum = { version = ">= 0.8, <= 0.9", default-features = false }
+ethereum = { version = "~0.7", default-features = false }
 environmental = { version = "1.1.2", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.10", default-features = false }
+primitive-types = { version = "~0.9", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 # Work-around for https://github.com/myrrlyn/funty/issues/3

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.10", default-features = false }
+primitive-types = { version = "~0.9", default-features = false }
 evm-core = { version = "0.30", path = "../core", default-features = false }
 evm-runtime = { version = "0.30", path = "../runtime", default-features = false }
 environmental = { version = "1.1.2", default-features = false, optional = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 evm-core = { version = "0.30", path = "../core", default-features = false }
-primitive-types = { version = "0.10", default-features = false }
+primitive-types = { version = "~0.9", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 environmental = { version = "1.1.2", default-features = false, optional = true}
 


### PR DESCRIPTION
This fixes the compatibility issues that we are facing right now. This shouldn't break for anyone.