### PR TITLE
WIP: Optimize disabled tracing

### DIFF
--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -12,8 +12,10 @@ pub mod tracing;
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
-		$x.emit();
-	};
+		if crate::tracing::is_tracing_enabled() {
+			$x.emit();
+		}
+	}
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -1,7 +1,8 @@
 //! EVM gasometer.
 
 #![deny(warnings)]
-#![forbid(unsafe_code, unused_variables)]
+#![forbid(unused_variables)]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "tracing")]

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -1,25 +1,28 @@
 //! Allows to listen to gasometer events.
 
 use super::Snapshot;
+use core::cell::RefCell;
 
 environmental::environmental!(listener: dyn EventListener + 'static);
 
 #[cfg(feature = "std")]
 std::thread_local! {
-	static ENABLE_TRACING: AtomicBool = AtomicBool::new(false);
+	static ENABLE_TRACING: RefCell<bool> = RefCell::new(false);
 }
 
+// We assume wasm is not multi-threaded.
+// This is the same assumption as the environmental crate.
 #[cfg(not(feature = "std"))]
-static ENABLE_TRACING: AtomicBool = AtomicBool::new(false);
+static ENABLE_TRACING: RefCell<bool> = RefCell::new(false);
 
 #[cfg(feature = "std")]
 pub fn enable_tracing(enable: bool) {
-	ENABLE_TRACING.with(|s| s.store(enable, Ordering::Relaxed));
+	ENABLE_TRACING.with(|s| s.replace(enable));
 }
 
 #[cfg(not(feature = "std"))]
 pub fn enable_tracing(enable: bool) {
-	ENABLE_TRACING.store(enable, Ordering::Relaxed);
+	ENABLE_TRACING.replace(enable);
 }
 
 pub trait EventListener {
@@ -62,7 +65,7 @@ impl Event {
 	#[cfg(feature = "std")]
 	pub(crate) fn emit(self) {
 		ENABLE_TRACING.with(|s| {
-			if s.load(Ordering::Relaxed) {
+			if *s.borrow() {
 				listener::with(|listener| listener.event(self));
 			}
 		})
@@ -70,7 +73,7 @@ impl Event {
 
 	#[cfg(not(feature = "std"))]
 	pub(crate) fn emit(self) {
-		if ENABLE_TRACING.load(Ordering::Relaxed) {
+		if *ENABLE_TRACING.borrow() {
 			listener::with(|listener| listener.event(self));
 		}
 	}

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -4,6 +4,24 @@ use super::Snapshot;
 
 environmental::environmental!(listener: dyn EventListener + 'static);
 
+#[cfg(feature = "std")]
+std::thread_local! {
+	static ENABLE_TRACING: AtomicBool = AtomicBool::new(false);
+}
+
+#[cfg(not(feature = "std"))]
+static ENABLE_TRACING: AtomicBool = AtomicBool::new(false);
+
+#[cfg(feature = "std")]
+pub fn enable_tracing(enable: bool) {
+	ENABLE_TRACING.with(|s| s.store(enable, Ordering::Relaxed));
+}
+
+#[cfg(not(feature = "std"))]
+pub fn enable_tracing(enable: bool) {
+	ENABLE_TRACING.store(enable, Ordering::Relaxed);
+}
+
 pub trait EventListener {
 	fn event(&mut self, event: Event);
 }
@@ -41,8 +59,20 @@ pub enum Event {
 }
 
 impl Event {
+	#[cfg(feature = "std")]
 	pub(crate) fn emit(self) {
-		listener::with(|listener| listener.event(self));
+		ENABLE_TRACING.with(|s| {
+			if s.load(Ordering::Relaxed) {
+				listener::with(|listener| listener.event(self));
+			}
+		})
+	}
+
+	#[cfg(not(feature = "std"))]
+	pub(crate) fn emit(self) {
+		if ENABLE_TRACING.load(Ordering::Relaxed) {
+			listener::with(|listener| listener.event(self));
+		}
 	}
 }
 

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -31,6 +31,16 @@ pub fn enable_tracing(enable: bool) {
 	ENABLE_TRACING.0.replace(enable);
 }
 
+#[cfg(feature = "std")]
+pub fn is_tracing_enabled() -> bool {
+	ENABLE_TRACING.with(|s| *s.borrow())
+}
+
+#[cfg(not(feature = "std"))]
+pub fn is_tracing_enabled() -> bool {
+	*ENABLE_TRACING.0.borrow()
+}
+
 pub trait EventListener {
 	fn event(&mut self, event: Event);
 }
@@ -70,18 +80,12 @@ pub enum Event {
 impl Event {
 	#[cfg(feature = "std")]
 	pub(crate) fn emit(self) {
-		ENABLE_TRACING.with(|s| {
-			if *s.borrow() {
-				listener::with(|listener| listener.event(self));
-			}
-		})
+		listener::with(|listener| listener.event(self));
 	}
 
 	#[cfg(not(feature = "std"))]
 	pub(crate) fn emit(self) {
-		if *ENABLE_TRACING.0.borrow() {
-			listener::with(|listener| listener.event(self));
-		}
+		listener::with(|listener| listener.event(self));
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,8 +14,10 @@ pub mod tracing;
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
-		$x.emit();
-	};
+		if crate::tracing::is_tracing_enabled() {
+			$x.emit();
+		}
+	}
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,7 +1,8 @@
 //! Runtime layer for EVM.
 
 #![deny(warnings)]
-#![forbid(unsafe_code, unused_variables)]
+#![forbid(unused_variables)]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -32,6 +32,16 @@ pub fn enable_tracing(enable: bool) {
 	ENABLE_TRACING.0.replace(enable);
 }
 
+#[cfg(feature = "std")]
+pub fn is_tracing_enabled() -> bool {
+	ENABLE_TRACING.with(|s| *s.borrow())
+}
+
+#[cfg(not(feature = "std"))]
+pub fn is_tracing_enabled() -> bool {
+	*ENABLE_TRACING.0.borrow()
+}
+
 pub trait EventListener {
 	fn event(&mut self, event: Event);
 }
@@ -64,18 +74,12 @@ pub enum Event<'a> {
 impl<'a> Event<'a> {
 	#[cfg(feature = "std")]
 	pub(crate) fn emit(self) {
-		ENABLE_TRACING.with(|s| {
-			if *s.borrow() {
-				listener::with(|listener| listener.event(self));
-			}
-		})
+		listener::with(|listener| listener.event(self));
 	}
 
 	#[cfg(not(feature = "std"))]
 	pub(crate) fn emit(self) {
-		if *ENABLE_TRACING.0.borrow() {
-			listener::with(|listener| listener.event(self));
-		}
+		listener::with(|listener| listener.event(self));
 	}
 }
 

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -14,7 +14,13 @@ std::thread_local! {
 // We assume wasm is not multi-threaded.
 // This is the same assumption as the environmental crate.
 #[cfg(not(feature = "std"))]
-static ENABLE_TRACING: RefCell<bool> = RefCell::new(false);
+struct WasmCell(RefCell<bool>);
+
+#[cfg(not(feature = "std"))]
+unsafe impl Sync for WasmCell {}
+
+#[cfg(not(feature = "std"))]
+static ENABLE_TRACING: WasmCell = WasmCell(RefCell::new(false));
 
 #[cfg(feature = "std")]
 pub fn enable_tracing(enable: bool) {
@@ -23,7 +29,7 @@ pub fn enable_tracing(enable: bool) {
 
 #[cfg(not(feature = "std"))]
 pub fn enable_tracing(enable: bool) {
-	ENABLE_TRACING.replace(enable);
+	ENABLE_TRACING.0.replace(enable);
 }
 
 pub trait EventListener {
@@ -67,7 +73,7 @@ impl<'a> Event<'a> {
 
 	#[cfg(not(feature = "std"))]
 	pub(crate) fn emit(self) {
-		if *ENABLE_TRACING.borrow() {
+		if *ENABLE_TRACING.0.borrow() {
 			listener::with(|listener| listener.event(self));
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! Ethereum Virtual Machine implementation in Rust
 
 #![deny(warnings)]
-#![forbid(unsafe_code, unused_variables)]
+#![forbid(unused_variables)]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,10 @@ pub mod tracing;
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
-		$x.emit();
-	};
+		if crate::tracing::is_tracing_enabled() {
+			$x.emit();
+		}
+	}
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -15,7 +15,13 @@ std::thread_local! {
 // We assume wasm is not multi-threaded.
 // This is the same assumption as the environmental crate.
 #[cfg(not(feature = "std"))]
-static ENABLE_TRACING: RefCell<bool> = RefCell::new(false);
+struct WasmCell(RefCell<bool>);
+
+#[cfg(not(feature = "std"))]
+unsafe impl Sync for WasmCell {}
+
+#[cfg(not(feature = "std"))]
+static ENABLE_TRACING: WasmCell = WasmCell(RefCell::new(false));
 
 #[cfg(feature = "std")]
 pub fn enable_tracing(enable: bool) {
@@ -24,7 +30,7 @@ pub fn enable_tracing(enable: bool) {
 
 #[cfg(not(feature = "std"))]
 pub fn enable_tracing(enable: bool) {
-	ENABLE_TRACING.replace(enable);
+	ENABLE_TRACING.0.replace(enable);
 }
 
 pub trait EventListener {
@@ -68,7 +74,7 @@ impl<'a> Event<'a> {
 
 	#[cfg(not(feature = "std"))]
 	pub(crate) fn emit(self) {
-		if *ENABLE_TRACING.borrow() {
+		if *ENABLE_TRACING.0.borrow() {
 			listener::with(|listener| listener.event(self));
 		}
 	}

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -33,6 +33,16 @@ pub fn enable_tracing(enable: bool) {
 	ENABLE_TRACING.0.replace(enable);
 }
 
+#[cfg(feature = "std")]
+pub fn is_tracing_enabled() -> bool {
+	ENABLE_TRACING.with(|s| *s.borrow())
+}
+
+#[cfg(not(feature = "std"))]
+pub fn is_tracing_enabled() -> bool {
+	*ENABLE_TRACING.0.borrow()
+}
+
 pub trait EventListener {
 	fn event(&mut self, event: Event);
 }
@@ -65,18 +75,12 @@ pub enum Event<'a> {
 impl<'a> Event<'a> {
 	#[cfg(feature = "std")]
 	pub(crate) fn emit(self) {
-		ENABLE_TRACING.with(|s| {
-			if *s.borrow() {
-				listener::with(|listener| listener.event(self));
-			}
-		})
+		listener::with(|listener| listener.event(self));
 	}
 
 	#[cfg(not(feature = "std"))]
 	pub(crate) fn emit(self) {
-		if *ENABLE_TRACING.0.borrow() {
-			listener::with(|listener| listener.event(self));
-		}
+		listener::with(|listener| listener.event(self));
 	}
 }
 

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -2,8 +2,8 @@
 
 use crate::Context;
 use core::cell::RefCell;
-use evm_runtime::{CreateScheme, Transfer};
-use primitive_types::{H160, U256};
+use evm_runtime::{CreateScheme, Transfer, ExitReason};
+use primitive_types::{H160, H256, U256};
 
 environmental::environmental!(listener: dyn EventListener + 'static);
 
@@ -68,8 +68,34 @@ pub enum Event<'a> {
 	Suicide {
 		address: H160,
 		target: H160,
-		balance: U256,
+        balance: U256,
+    },
+	Exit {
+		reason: &'a ExitReason,
+		return_value: &'a [u8],
 	},
+	TransactCall {
+		caller: H160,
+		address: H160,
+		value: U256,
+		data: &'a [u8],
+		gas_limit: u64,
+	},
+	TransactCreate {
+		caller: H160,
+		value: U256,
+		init_code: &'a [u8],
+		gas_limit: u64,
+		address: H160,
+	},
+	TransactCreate2 {
+		caller: H160,
+		value: U256,
+		init_code: &'a [u8],
+		salt: H256,
+		gas_limit: u64,
+		address: H160,
+	}
 }
 
 impl<'a> Event<'a> {


### PR DESCRIPTION
If a runtime (like Moonbeam) needs the `tracing` features it must be enabled for the entire runtime (since it is the same shared Wasm blob for block production and block replaying for tracing).

This has huge performance impacts even when no listener is registered, such as when producing blocks. This PR just adds a "short-circuit" global boolean to skip interacting with the environmental if tracing is not enabled (at runtime), as a lot of time was spent in the environmental code (while producing blocks). The check is done inside the macro around the provided expression, which will avoid computing the event data if tracing is disabled.

Our benchmarks shows slightly better performance using the `RefCell` than `AtomicBool`.
Additional benchmarks are needed to see the impact of the check in the macro.

# About unsafe code

In no_std (wasm) we make the same assumption as the environmental crate that the execution is single-threaded. Thus it is safe to use a `RefCell`, and to `unsafe impl Sync` for a wrapper struct.

I had to remove the forbid lint for unsafe_code to impl `Sync`, but I can add it back such that it ignores the no_std + tracing case.