### PR TITLE
Enable TRACE as const generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,6 @@ default = ["std"]
 with-codec = ["codec", "evm-core/with-codec", "primitive-types/codec", "ethereum/with-codec"]
 with-serde = ["serde", "evm-core/with-serde", "primitive-types/serde", "ethereum/with-serde"]
 std = ["evm-core/std", "evm-gasometer/std", "evm-runtime/std", "sha3/std", "primitive-types/std", "serde/std", "codec/std", "log/std", "ethereum/std", "environmental/std"]
-tracing = [
-  "environmental"
-]
 
 [workspace]
 members = [

--- a/benches/loop.rs
+++ b/benches/loop.rs
@@ -45,7 +45,7 @@ fn run_loop_contract() {
 	let state = MemoryStackState::new(metadata, &backend);
 	let mut executor = StackExecutor::new(state, &config);
 
-	let _reason = executor.transact_call(
+	let _reason = executor.transact_call::<false, false, false>(
 		H160::from_str("0xf000000000000000000000000000000000000000").unwrap(),
 		H160::from_str("0x1000000000000000000000000000000000000000").unwrap(),
 		U256::zero(),

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -22,6 +22,3 @@ std = [
   "primitive-types/std",
   "environmental/std"
 ]
-tracing = [
-  "environmental"
-]

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -6,21 +6,14 @@
 
 extern crate alloc;
 
-//#[cfg(feature = "tracing")]
 pub mod tracing;
 
-//#[cfg(feature = "tracing")]
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
 		$x.emit();
 	};
 }
-
-// #[cfg(not(feature = "tracing"))]
-// macro_rules! event {
-// 	($x:expr) => {};
-// }
 
 mod consts;
 mod costs;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,6 +17,3 @@ environmental = { version = "1.1.2", default-features = false, optional = true}
 [features]
 default = ["std"]
 std = ["evm-core/std", "primitive-types/std", "sha3/std", "environmental/std"]
-tracing = [
-  "environmental"
-]

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -75,9 +75,13 @@ pub trait Handler {
 	/// Create a log owned by address with given topics and data.
 	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) -> Result<(), ExitError>;
 	/// Mark an address to be deleted, with funds transferred to target.
-	fn mark_delete(&mut self, address: H160, target: H160) -> Result<(), ExitError>;
+	fn mark_delete<const CALL_TRACE: bool>(
+		&mut self,
+		address: H160,
+		target: H160,
+	) -> Result<(), ExitError>;
 	/// Invoke a create operation.
-	fn create(
+	fn create<const CALL_TRACE: bool, const GAS_TRACE: bool, const OPCODE_TRACE: bool>(
 		&mut self,
 		caller: H160,
 		scheme: CreateScheme,
@@ -90,7 +94,7 @@ pub trait Handler {
 		Ok(())
 	}
 	/// Invoke a call operation.
-	fn call(
+	fn call<const CALL_TRACE: bool, const GAS_TRACE: bool, const OPCODE_TRACE: bool>(
 		&mut self,
 		code_address: H160,
 		transfer: Option<Transfer>,
@@ -105,7 +109,7 @@ pub trait Handler {
 	}
 
 	/// Pre-validation step for the runtime.
-	fn pre_validate(
+	fn pre_validate<const GAS_PRICE: bool>(
 		&mut self,
 		context: &Context,
 		opcode: Opcode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,22 +8,14 @@ extern crate alloc;
 
 pub use evm_core::*;
 pub use evm_gasometer as gasometer;
-pub use evm_runtime::*;
+pub use evm_runtime::{self as runtime, *};
 
-#[cfg(feature = "tracing")]
 pub mod tracing;
-
-#[cfg(feature = "tracing")]
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
 		$x.emit();
 	};
-}
-
-#[cfg(not(feature = "tracing"))]
-macro_rules! event {
-	($x:expr) => {};
 }
 
 pub mod backend;


### PR DESCRIPTION
Hi, currently if we wanted to use tracing inside sputnik we would need to enable `tracing` flag that will affect our execution performance. With const generics, it is easier to use tracing and we don't have that performance penalty.

I added three flags for tracing: `CALL_TRACE`, `OPCODE_TRACE`, `GAS_TRACE`, removed tracing flag and set runtime tracing as pub so that it can be accessed.

We should probably add default's for const generics when they become available in Rust.