### PR TITLE
Add new tracing events

### DIFF
--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -13,6 +13,26 @@ use ethereum::Log;
 use primitive_types::{H160, H256, U256};
 use sha3::{Digest, Keccak256};
 
+macro_rules! emit_exit {
+	($reason:expr) => {{
+		let reason = $reason;
+		event!(Exit {
+			reason: &reason,
+			return_value: &Vec::new(),
+		});
+		reason
+	}};
+	($reason:expr, $return_value:expr) => {{
+		let reason = $reason;
+		let return_value = $return_value;
+		event!(Exit {
+			reason: &reason,
+			return_value: &return_value,
+		});
+		(reason, return_value)
+	}};
+}
+
 pub enum StackExitKind {
 	Succeeded,
 	Reverted,
@@ -182,6 +202,14 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		init_code: Vec<u8>,
 		gas_limit: u64,
 	) -> ExitReason {
+		event!(TransactCreate {
+			caller,
+			value,
+			init_code: &init_code,
+			gas_limit,
+			address: self.create_address(CreateScheme::Legacy { caller }),
+		});
+
 		let transaction_cost = gasometer::create_transaction_cost(&init_code);
 		match self
 			.state
@@ -190,7 +218,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			.record_transaction(transaction_cost)
 		{
 			Ok(()) => (),
-			Err(e) => return e.into(),
+			Err(e) => return emit_exit!(e.into()),
 		}
 
 		match self.create_inner(
@@ -201,7 +229,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			Some(gas_limit),
 			false,
 		) {
-			Capture::Exit((s, _, _)) => s,
+			Capture::Exit((s, _, _)) => emit_exit!(s),
 			Capture::Trap(_) => unreachable!(),
 		}
 	}
@@ -215,6 +243,19 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		salt: H256,
 		gas_limit: u64,
 	) -> ExitReason {
+		event!(TransactCreate2 {
+			caller,
+			value,
+			init_code: &init_code,
+			salt,
+			gas_limit,
+			address: self.create_address(CreateScheme::Create2 {
+				caller,
+				code_hash: H256::from_slice(Keccak256::digest(&init_code).as_slice()),
+				salt,
+			}),
+		});
+
 		let transaction_cost = gasometer::create_transaction_cost(&init_code);
 		match self
 			.state
@@ -223,7 +264,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			.record_transaction(transaction_cost)
 		{
 			Ok(()) => (),
-			Err(e) => return e.into(),
+			Err(e) => return emit_exit!(e.into()),
 		}
 		let code_hash = H256::from_slice(Keccak256::digest(&init_code).as_slice());
 
@@ -239,7 +280,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			Some(gas_limit),
 			false,
 		) {
-			Capture::Exit((s, _, _)) => s,
+			Capture::Exit((s, _, _)) => emit_exit!(s),
 			Capture::Trap(_) => unreachable!(),
 		}
 	}
@@ -253,6 +294,14 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		data: Vec<u8>,
 		gas_limit: u64,
 	) -> (ExitReason, Vec<u8>) {
+		event!(TransactCall {
+			caller,
+			address,
+			value,
+			data: &data,
+			gas_limit,
+		});
+
 		let transaction_cost = gasometer::call_transaction_cost(&data);
 		match self
 			.state
@@ -261,7 +310,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			.record_transaction(transaction_cost)
 		{
 			Ok(()) => (),
-			Err(e) => return (e.into(), Vec::new()),
+			Err(e) => return emit_exit!(e.into(), Vec::new()),
 		}
 
 		self.state.inc_nonce(caller);
@@ -286,7 +335,7 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			false,
 			context,
 		) {
-			Capture::Exit((s, v)) => (s, v),
+			Capture::Exit((s, v)) => emit_exit!(s, v),
 			Capture::Trap(_) => unreachable!(),
 		}
 	}
@@ -753,6 +802,7 @@ impl<'config, S: StackState<'config>> Handler for StackExecutor<'config, S> {
 		Ok(())
 	}
 
+	#[cfg(not(feature = "tracing"))]
 	fn create(
 		&mut self,
 		caller: H160,
@@ -764,6 +814,25 @@ impl<'config, S: StackState<'config>> Handler for StackExecutor<'config, S> {
 		self.create_inner(caller, scheme, value, init_code, target_gas, true)
 	}
 
+	#[cfg(feature = "tracing")]
+	fn create(
+		&mut self,
+		caller: H160,
+		scheme: CreateScheme,
+		value: U256,
+		init_code: Vec<u8>,
+		target_gas: Option<u64>,
+	) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Self::CreateInterrupt> {
+		let capture = self.create_inner(caller, scheme, value, init_code, target_gas, true);
+
+		if let Capture::Exit((ref reason, _, ref return_value)) = capture {
+			emit_exit!(reason, return_value);
+		}
+
+		capture
+	}
+
+	#[cfg(not(feature = "tracing"))]
 	fn call(
 		&mut self,
 		code_address: H160,
@@ -783,6 +852,34 @@ impl<'config, S: StackState<'config>> Handler for StackExecutor<'config, S> {
 			true,
 			context,
 		)
+	}
+
+	#[cfg(feature = "tracing")]
+	fn call(
+		&mut self,
+		code_address: H160,
+		transfer: Option<Transfer>,
+		input: Vec<u8>,
+		target_gas: Option<u64>,
+		is_static: bool,
+		context: Context,
+	) -> Capture<(ExitReason, Vec<u8>), Self::CallInterrupt> {
+		let capture = self.call_inner(
+			code_address,
+			transfer,
+			input,
+			target_gas,
+			is_static,
+			true,
+			true,
+			context,
+		);
+
+		if let Capture::Exit((ref reason, ref return_value)) = capture {
+			emit_exit!(reason, return_value);
+		}
+
+		capture
 	}
 
 	#[inline]

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,8 +1,8 @@
 //! Allows to listen to runtime events.
 
 use crate::Context;
-use evm_runtime::{CreateScheme, Transfer};
-use primitive_types::{H160, U256};
+use evm_runtime::{CreateScheme, ExitReason, Transfer};
+use primitive_types::{H160, H256, U256};
 
 environmental::environmental!(listener: dyn EventListener + 'static);
 
@@ -32,6 +32,32 @@ pub enum Event<'a> {
 		address: H160,
 		target: H160,
 		balance: U256,
+	},
+	Exit {
+		reason: &'a ExitReason,
+		return_value: &'a [u8],
+	},
+	TransactCall {
+		caller: H160,
+		address: H160,
+		value: U256,
+		data: &'a [u8],
+		gas_limit: u64,
+	},
+	TransactCreate {
+		caller: H160,
+		value: U256,
+		init_code: &'a [u8],
+		gas_limit: u64,
+		address: H160,
+	},
+	TransactCreate2 {
+		caller: H160,
+		value: U256,
+		init_code: &'a [u8],
+		salt: H256,
+		gas_limit: u64,
+		address: H160,
 	},
 }
 


### PR DESCRIPTION
Add 4 new events in the main crate : Exit, TransactCall, TransactCreate and TransactCreate2.

All the TransactX events guarantees that each transaction will emit at least one of those events, which contains all the important information about calls/creates. This information was not available in some edge cases before.

The Exit event is emitted in all return places of `transact_call`, `transact_create`, and inner `call`/`create`. Without this event it was not possible to have exit information when errors such as Out of Gas occured, or when calling precompiles. A small macro `emit_exit!` is added to wrap all expressions that are returned, calling the `event!` macro then returning the expression.

When `tracing` feature is disabled the `event!` macro is a no-op, making the `emit_exit!` identical to not using the macro.
In `call`/`create` since we have to match on the `Capture` which can have a (small) performance impact, I kept the non-matching version for when `tracing` is not enabled to skip this useless match.