### PR TITLE
Minimum supported rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Submodules
       run: |
         cd evm
+        git remote set-url origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
         git fetch origin $GITHUB_SHA
         git checkout $GITHUB_SHA
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 
 ## Dependencies
 
-Ensure you have at least `rustc 1.33.0 (2aa4c46cf 2019-02-28)`. Rust 1.32.0 and
-before is not supported.
+Ensure you have at least `rustc 1.51.0 (2fd73fabe 2021-03-23)`. Rust 1.50.0 and
+before are not supported.
 
 ## Documentation
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -117,7 +117,9 @@ pub enum ExitError {
 	OutOfFund,
 
 	/// PC underflowed (unused).
+	#[allow(clippy::upper_case_acronyms)]
 	PCUnderflow,
+
 	/// Attempt to create an empty account (runtime, unused).
 	CreateEmpty,
 

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -1,5 +1,4 @@
-use evm_core::{Capture, ExitSucceed, Machine};
-use honggfuzz::fuzz;
+use evm_core::Machine;
 use std::rc::Rc;
 
 fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -17,10 +16,10 @@ fn split_at_delim(sequence: &[u8], delim: &[u8]) -> (Vec<u8>, Vec<u8>) {
 		current_pos = found_index + delim.len();
 	}
 	if current_pos == 0 {
-		return (sequence.to_vec(), Vec::new());
+		(sequence.to_vec(), Vec::new())
 	} else {
 		res_vec.push(sequence[current_pos..].to_vec());
-		return (res_vec[0].to_owned(), res_vec[1].to_owned());
+		(res_vec[0].to_owned(), res_vec[1].to_owned())
 	}
 }
 
@@ -39,6 +38,8 @@ fn handle_data(sequence: &[u8]) {
 fn main() {
 	#[cfg(fuzzing)]
 	{
+		use honggfuzz::fuzz;
+
 		loop {
 			fuzz!(|data: &[u8]| {
 				handle_data(data);

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -272,6 +272,7 @@ impl<'config> Gasometer<'config> {
 }
 
 /// Calculate the call transaction cost.
+#[allow(clippy::naive_bytecount)]
 pub fn call_transaction_cost(data: &[u8], access_list: &[(H160, Vec<H256>)]) -> TransactionCost {
 	let zero_data_len = data.iter().filter(|v| **v == 0).count();
 	let non_zero_data_len = data.len() - zero_data_len;
@@ -286,6 +287,7 @@ pub fn call_transaction_cost(data: &[u8], access_list: &[(H160, Vec<H256>)]) -> 
 }
 
 /// Calculate the create transaction cost.
+#[allow(clippy::naive_bytecount)]
 pub fn create_transaction_cost(data: &[u8], access_list: &[(H160, Vec<H256>)]) -> TransactionCost {
 	let zero_data_len = data.iter().filter(|v| **v == 0).count();
 	let non_zero_data_len = data.len() - zero_data_len;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.51.0"
+profile = "minimal"
+components = [ "rustfmt", "clippy" ]

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -340,8 +340,8 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 			let addresses = self
 				.precompile
 				.clone()
-				.into_keys()
 				.into_iter()
+				.map(|(k, _)| k)
 				.chain(core::iter::once(caller))
 				.chain(core::iter::once(address));
 			self.state.metadata_mut().access_addresses(addresses);
@@ -459,7 +459,12 @@ impl<'config, S: StackState<'config>> StackExecutor<'config, S> {
 		self.state.metadata_mut().access_address(caller);
 		self.state.metadata_mut().access_address(address);
 
-		let addresses: Vec<H160> = self.precompile.clone().into_keys().collect();
+		let addresses: Vec<H160> = self
+			.precompile
+			.clone()
+			.into_iter()
+			.map(|(k, _)| k)
+			.collect();
 		self.state
 			.metadata_mut()
 			.access_addresses(addresses.iter().copied());


### PR DESCRIPTION
This bumps the _documented_ minimum supported Rust version to 1.51 (the latest in Ubuntu 21.04) , and actually enforces it in CI.

Prior to this PR, the actual MSRV was more like 1.54, when [`into_keys`](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html#method.into_keys) was introduced.

Also includes a quick hack to fix the jsontest CI step in other repositories.