### PR TITLE
Only evaluate event expression if a tracing listener is in place

### DIFF
--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -13,8 +13,8 @@ pub mod tracing;
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
-		$x.emit();
-	};
+		crate::tracing::with(|listener| listener.event($x));
+	}
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -14,7 +14,7 @@ macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
 		crate::tracing::with(|listener| listener.event($x));
-	}
+	};
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -40,10 +40,11 @@ pub enum Event {
 	},
 }
 
-impl Event {
-	pub(crate) fn emit(self) {
-		listener::with(|listener| listener.event(self));
-	}
+// Expose `listener::with` to the crate only.
+pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(
+	f: F
+) {
+	listener::with(f);
 }
 
 /// Run closure with provided listener.

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -41,9 +41,7 @@ pub enum Event {
 }
 
 // Expose `listener::with` to the crate only.
-pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(
-	f: F
-) {
+pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(f: F) {
 	listener::with(f);
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,8 +13,8 @@ pub mod tracing;
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
-		$x.emit();
-	};
+		crate::tracing::with(|listener| listener.event($x));
+	}
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,7 +14,7 @@ macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
 		crate::tracing::with(|listener| listener.event($x));
-	}
+	};
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -35,9 +35,7 @@ pub enum Event<'a> {
 }
 
 // Expose `listener::with` to the crate only.
-pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(
-	f: F
-) {
+pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(f: F) {
 	listener::with(f);
 }
 

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -34,10 +34,11 @@ pub enum Event<'a> {
 	},
 }
 
-impl<'a> Event<'a> {
-	pub(crate) fn emit(self) {
-		listener::with(|listener| listener.event(self));
-	}
+// Expose `listener::with` to the crate only.
+pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(
+	f: F
+) {
+	listener::with(f);
 }
 
 /// Run closure with provided listener.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
 		crate::tracing::with(|listener| listener.event($x));
-	}
+	};
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ pub mod tracing;
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
-		$x.emit();
-	};
+		crate::tracing::with(|listener| listener.event($x));
+	}
 }
 
 #[cfg(not(feature = "tracing"))]

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -61,10 +61,11 @@ pub enum Event<'a> {
 	},
 }
 
-impl<'a> Event<'a> {
-	pub(crate) fn emit(self) {
-		listener::with(|listener| listener.event(self));
-	}
+// Expose `listener::with` to the crate only.
+pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(
+	f: F
+) {
+	listener::with(f);
 }
 
 /// Run closure with provided listener.

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -62,9 +62,7 @@ pub enum Event<'a> {
 }
 
 // Expose `listener::with` to the crate only.
-pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(
-	f: F
-) {
+pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(f: F) {
 	listener::with(f);
 }
 


### PR DESCRIPTION
Currently the events expression are evaluated regardless of if there is actually a listener in the environmental. This can cause performance issues if a runtime needs to enable the compile-time tracing feature but is not always actually listening to events (so anytime outside of tracing RPC and alike).

This PR moves the event expression inside the closure provided to the environmental, which will be executed only if there is a listener in place. It changes no public API, doesn't impact the crates with `tracing` feature off, and will reduce the overhead to only the environmental access in the case `tracing` feature is on but no listener is registered.