### PR TITLE
feat: implement clone/debug for state structs

### DIFF
--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -54,7 +54,7 @@ pub struct Snapshot {
 }
 
 /// EVM gasometer.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Gasometer<'config> {
 	gas_limit: u64,
 	config: &'config Config,
@@ -674,7 +674,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 }
 
 /// Holds the gas consumption for a Gasometer instance.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Inner<'config> {
 	memory_gas: u64,
 	used_gas: u64,

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -24,6 +24,7 @@ pub enum StackExitKind {
 }
 
 #[derive(Default)]
+#[derive(Clone, Debug)]
 struct Accessed {
 	accessed_addresses: BTreeSet<H160>,
 	accessed_storage: BTreeSet<(H160, H256)>,
@@ -53,6 +54,7 @@ impl Accessed {
 	}
 }
 
+#[derive(Clone, Debug)]
 pub struct StackSubstateMetadata<'config> {
 	gasometer: Gasometer<'config>,
 	is_static: bool,

--- a/src/executor/stack/state.rs
+++ b/src/executor/stack/state.rs
@@ -16,6 +16,7 @@ struct MemoryStackAccount {
 	pub reset: bool,
 }
 
+#[derive(Clone, Debug)]
 pub struct MemoryStackSubstate<'config> {
 	metadata: StackSubstateMetadata<'config>,
 	parent: Option<Box<MemoryStackSubstate<'config>>>,
@@ -409,6 +410,7 @@ pub trait StackState<'config>: Backend {
 	fn touch(&mut self, address: H160);
 }
 
+#[derive(Clone, Debug)]
 pub struct MemoryStackState<'backend, 'config, B> {
 	backend: &'backend B,
 	substate: MemoryStackSubstate<'config>,


### PR DESCRIPTION
As title. Sometimes consumers may _really_ want to Clone the state structs despite them being potentially large in-mem maps, so it seems like this is something we could easily merge.