### PR TITLE
feat: expose mutable ref to logs so that they can be cleared

### DIFF
--- a/src/executor/stack/state.rs
+++ b/src/executor/stack/state.rs
@@ -42,6 +42,10 @@ impl<'config> MemoryStackSubstate<'config> {
 		&self.logs
 	}
 
+	pub fn logs_mut(&mut self) -> &mut Vec<Log> {
+		&mut self.logs
+	}
+
 	pub fn metadata(&self) -> &StackSubstateMetadata<'config> {
 		&self.metadata
 	}


### PR DESCRIPTION
this allows cleaning up logs across evm executions, letting a consumer fetch them and log them to the user