### PR TITLE
Support a wider range of `ethereum`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm"
-version = "0.31.0"
+version = "0.31.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
@@ -18,7 +18,7 @@ rlp = { version = "0.5", default-features = false }
 primitive-types = { version = "0.10", default-features = false, features = ["rlp"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"], optional = true }
-ethereum = { version = "~0.8", default-features = false }
+ethereum = { version = ">= 0.8, < 0.11", default-features = false }
 environmental = { version = "1.1.2", default-features = false, optional = true }
 auto_impl = "0.4.1"
 


### PR DESCRIPTION
Adds `ethereum` v0.10 support. rel https://github.com/rust-blockchain/ethereum/pull/27