### PR TITLE
Remove auto_impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ codec = { package = "parity-scale-codec", version = "2.0", default-features = fa
 ethereum = { version = "0.10", default-features = false }
 environmental = { version = "1.1.2", default-features = false, optional = true }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
-auto_impl = "0.4.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,7 +13,6 @@ evm-core = { version = "0.31", path = "../core", default-features = false }
 primitive-types = { version = "0.10", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 environmental = { version = "1.1.2", default-features = false, optional = true}
-auto_impl = "0.4.1"
 
 [features]
 default = ["std"]

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -14,7 +14,6 @@ pub struct Transfer {
 }
 
 /// EVM context handler.
-#[auto_impl::auto_impl(&mut, Box)]
 pub trait Handler {
 	/// Type of `CREATE` interrupt.
 	type CreateInterrupt;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -50,7 +50,6 @@ pub enum Apply<I> {
 }
 
 /// EVM backend.
-#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait Backend {
 	/// Gas price.
 	fn gas_price(&self) -> U256;

--- a/src/executor/stack/state.rs
+++ b/src/executor/stack/state.rs
@@ -393,7 +393,6 @@ impl<'config> MemoryStackSubstate<'config> {
 	}
 }
 
-#[auto_impl::auto_impl(&mut, Box)]
 pub trait StackState<'config>: Backend {
 	fn metadata(&self) -> &StackSubstateMetadata<'config>;
 	fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config>;


### PR DESCRIPTION
It's not `no_std` compatible. We still need to work on the `no_std` CI to make sure this does not happen again. rel https://github.com/rust-blockchain/evm/pull/62#issuecomment-949140071