### PR TITLE
`tracing-step` feature for `evm-runtime`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,11 @@ tracing = [
   "evm-gasometer/tracing",
   "evm-runtime/tracing"
 ]
+tracing-step = [
+  "environmental",
+  "evm-gasometer/tracing",
+  "evm-runtime/tracing-step"
+]
 
 [workspace]
 members = [

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,3 +20,4 @@ std = ["evm-core/std", "primitive-types/std", "sha3/std", "environmental/std"]
 tracing = [
   "environmental"
 ]
+tracing-step = [ "tracing" ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -39,6 +39,7 @@ use alloc::vec::Vec;
 macro_rules! step {
 	( $self:expr, $handler:expr, $return:tt $($err:path)?; $($ok:path)? ) => ({
 		if let Some((opcode, stack)) = $self.machine.inspect() {
+			#[cfg(feature = "tracing-step")]
 			event!(Step {
 				context: &$self.context,
 				opcode,


### PR DESCRIPTION
Emitting `RuntimeEvent::Step` is costly under some circumstances, for example when the `Memory` layout is huge. This has a big impact in tracing performance.

This PR introduces a new `tracing-step` feature to gate this event.