### PR TITLE
feat: reintroduce auto-impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ codec = { package = "parity-scale-codec", version = "2.0", default-features = fa
 ethereum = { version = "0.10", default-features = false }
 environmental = { version = "1.1.2", default-features = false, optional = true }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }
+auto_impl = "0.5.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,6 +13,7 @@ evm-core = { version = "0.33", path = "../core", default-features = false }
 primitive-types = { version = "0.10", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 environmental = { version = "1.1.2", default-features = false, optional = true}
+auto_impl = "0.5.0"
 
 [features]
 default = ["std"]

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -14,6 +14,7 @@ pub struct Transfer {
 }
 
 /// EVM context handler.
+#[auto_impl::auto_impl(&mut, Box)]
 pub trait Handler {
 	/// Type of `CREATE` interrupt.
 	type CreateInterrupt;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -50,6 +50,7 @@ pub enum Apply<I> {
 }
 
 /// EVM backend.
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait Backend {
 	/// Gas price. Unused for London.
 	fn gas_price(&self) -> U256;

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -186,6 +186,7 @@ impl<'config> StackSubstateMetadata<'config> {
 	}
 }
 
+#[auto_impl::auto_impl(&mut, Box)]
 pub trait StackState<'config>: Backend {
 	fn metadata(&self) -> &StackSubstateMetadata<'config>;
 	fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config>;


### PR DESCRIPTION
Auto-impl should be no_std compatible since https://github.com/auto-impl-rs/auto_impl/pull/73, ref https://github.com/rust-blockchain/evm/pull/71 and https://github.com/rust-blockchain/evm/pull/62