### PR TITLE
Fix EIP-2929 cold slot costs for gasometer in estimation mode

### DIFF
--- a/gasometer/src/costs.rs
+++ b/gasometer/src/costs.rs
@@ -206,29 +206,33 @@ pub fn sstore_cost(
 	is_cold: bool,
 	config: &Config,
 ) -> Result<u64, ExitError> {
-	let gas_cost = if config.sstore_gas_metering {
-		if config.sstore_revert_under_stipend && gas <= config.call_stipend {
-			return Err(ExitError::OutOfGas);
-		}
-
-		if new == current {
-			config.gas_sload
-		} else {
-			if original == current {
-				if original == H256::zero() {
-					config.gas_sstore_set
-				} else {
-					config.gas_sstore_reset
-				}
-			} else {
-				config.gas_sload
-			}
-		}
+	let gas_cost = if config.estimate {
+		config.gas_sstore_set
 	} else {
-		if current == H256::zero() && new != H256::zero() {
-			config.gas_sstore_set
+		if config.sstore_gas_metering {
+			if config.sstore_revert_under_stipend && gas <= config.call_stipend {
+				return Err(ExitError::OutOfGas);
+			}
+
+			if new == current {
+				config.gas_sload
+			} else {
+				if original == current {
+					if original == H256::zero() {
+						config.gas_sstore_set
+					} else {
+						config.gas_sstore_reset
+					}
+				} else {
+					config.gas_sload
+				}
+			}
 		} else {
-			config.gas_sstore_reset
+			if current == H256::zero() && new != H256::zero() {
+				config.gas_sstore_set
+			} else {
+				config.gas_sstore_reset
+			}
 		}
 	};
 	Ok(

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -782,7 +782,6 @@ impl<'config> Inner<'config> {
 				target_exists,
 				..
 			} => costs::suicide_cost(value, target_is_cold, target_exists, self.config),
-			GasCost::SStore { .. } if self.config.estimate => self.config.gas_sstore_set,
 			GasCost::SStore {
 				original,
 				current,


### PR DESCRIPTION
When the gasometer is running in estimation mode the EIP-2929 cold slot costs are not added to the gas use, causing the estimation to underestimate the required gas.

This fixes the case and also moves the `if self.config.estimate` special case into the `sstore_cost` function to reduce the likelihood of the special case being missed again in the future.