### PR TITLE
feat: expose account_mut

### DIFF
--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -555,6 +555,11 @@ impl<'backend, 'config, B: Backend> MemoryStackState<'backend, 'config, B> {
 		}
 	}
 
+	/// Returns a mutable reference to an account given its address
+	pub fn account_mut(&mut self, address: H160) -> &mut MemoryStackAccount {
+		self.substate.account_mut(address, self.backend)
+	}
+
 	#[must_use]
 	pub fn deconstruct(
 		self,


### PR DESCRIPTION
as title, we need this to expose a mutable ref to an account so that we can override its nonce in https://github.com/gakonst/foundry/issues/554