### PR TITLE
optimize mload instruction to not allocate a temporary vector

### DIFF
--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -81,7 +81,7 @@ pub fn mload(state: &mut Machine) -> Control {
 	pop_u256!(state, index);
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
 	let index = as_usize_or_fail!(index);
-	let value = H256::from_slice(&state.memory.get(index, 32)[..]);
+	let value = state.memory.get_h256(index);
 	push!(state, value);
 	Control::Continue(1)
 }

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -2,7 +2,7 @@ use crate::{ExitError, ExitFatal};
 use alloc::vec::Vec;
 use core::cmp::min;
 use core::ops::{BitAnd, Not};
-use primitive_types::U256;
+use primitive_types::{U256, H256};
 
 /// A sequencial memory. It uses Rust's `Vec` for internal
 /// representation.
@@ -94,6 +94,23 @@ impl Memory {
 		}
 
 		ret
+	}
+
+	/// Get `H256` from a specific offset in memory.
+	pub fn get_h256(&self, offset: usize) -> H256 {
+		let mut ret = [0; 32];
+
+		#[allow(clippy::needless_range_loop)]
+		for index in 0..32 {
+			let position = offset + index;
+			if position >= self.data.len() {
+				break;
+			}
+
+			ret[index] = self.data[position];
+		}
+
+		H256(ret)
 	}
 
 	/// Set memory region at given offset. The offset and value is considered


### PR DESCRIPTION
Naked-eye based optimization -- it feels suboptimal to allocate a `Vec`
to fetch `[0; u32]`. Running a macro-benchmark in aurora shows that this
is about a 1% win,  so the compiler probably can't eliminate this vec
entirely.