### PR TITLE
feat(evm): expose account_mut on substate

### DIFF
--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -279,7 +279,7 @@ impl<'config> MemoryStackSubstate<'config> {
 	}
 
 	#[allow(clippy::map_entry)]
-	fn account_mut<B: Backend>(&mut self, address: H160, backend: &B) -> &mut MemoryStackAccount {
+	pub fn account_mut<B: Backend>(&mut self, address: H160, backend: &B) -> &mut MemoryStackAccount {
 		if !self.accounts.contains_key(&address) {
 			let account = self
 				.known_account(address)


### PR DESCRIPTION
@sorpaas unfortunately #92 wasn't sufficient because we have our own `MemoryStackStateOwned` implementation which owns the backend, so we do need to access the substate's method, instead of via the `MemoryStackState`. Would appreciate if we can get this merged with a quicker turnaround time, given our previous discussion