### PR TITLE
Create a contract with a fixed address

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -423,6 +423,42 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		}
 	}
 
+	/// Execute a `CREATE` transaction with fixed contract address.
+	pub fn transact_create_with_address(
+		&mut self,
+		caller: H160,
+		contract_address: H160,
+		value: U256,
+		init_code: Vec<u8>,
+		gas_limit: u64,
+		access_list: Vec<(H160, Vec<H256>)>, // See EIP-2930
+	) -> (ExitReason, Vec<u8>) {
+		event!(TransactCreate {
+			caller,
+			value,
+			init_code: &init_code,
+			gas_limit,
+			address: contract_address,
+		});
+
+		if let Err(e) = self.record_create_transaction_cost(&init_code, &access_list) {
+			return emit_exit!(e.into(), Vec::new());
+		}
+		self.initialize_with_access_list(access_list);
+
+		match self.create_inner(
+			caller,
+			CreateScheme::Fixed(contract_address),
+			value,
+			init_code,
+			Some(gas_limit),
+			false,
+		) {
+			Capture::Exit((s, _, v)) => emit_exit!(s, v),
+			Capture::Trap(_) => unreachable!(),
+		}
+	}
+
 	/// Execute a `CREATE2` transaction.
 	pub fn transact_create2(
 		&mut self,


### PR DESCRIPTION
Sometimes we need to create contracts with fixed addresses, like the [system contracts in bsc](https://github.com/bnb-chain/bsc/blob/46d185b4cfed54436f526b24c47b15ed58a5e1bb/core/systemcontracts/const.go)