### PR TITLE
PrecompileHandle trait

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -304,11 +304,12 @@ impl PrecompileSet for () {
 }
 
 /// Precompiles function signature. Expected input arguments are:
-///  * Handle
 ///  * Input
 ///  * Gas limit
 ///  * Context
 ///  * Is static
+///
+/// In case of success returns the output and the cost.
 pub type PrecompileFn =
 	fn(&[u8], Option<u64>, &Context, bool) -> Result<(PrecompileOutput, u64), PrecompileFailure>;
 

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -255,6 +255,8 @@ pub trait PrecompileHandle {
 
 	fn record_cost(&mut self, cost: u64) -> Result<(), ExitError>;
 
+	fn remaining_gas(&self) -> u64;
+
 	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>);
 }
 
@@ -1225,37 +1227,8 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Precompile
 	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) {
 		let _ = Handler::log(self, address, topics, data);
 	}
-}
 
-pub struct ExemplePrecompileSet;
-
-impl PrecompileSet for ExemplePrecompileSet {
-	fn execute<H: PrecompileHandle>(
-		&self,
-		handle: &mut H,
-		_address: H160,
-		_input: &[u8],
-		gas_limit: Option<u64>,
-		context: &Context,
-		_is_static: bool,
-	) -> Option<PrecompileResult> {
-		// Subcall
-		let (_status, _data) = handle.call(
-			H160::repeat_byte(0x11), // exemple,
-			None,
-			b"Test".to_vec(),
-			gas_limit,
-			false,
-			context,
-		);
-
-		todo!("do stuff with the result")
-	}
-
-	/// Check if the given address is a precompile. Should only be called to
-	/// perform the check while not executing the precompile afterward, since
-	/// `execute` already performs a check internally.
-	fn is_precompile(&self, _address: H160) -> bool {
-		todo!()
+	fn remaining_gas(&self) -> u64  {
+		self.state.metadata().gasometer.gas()
 	}
 }

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -269,9 +269,9 @@ pub type PrecompileResult = Result<PrecompileOutput, PrecompileFailure>;
 pub trait PrecompileSet {
 	/// Tries to execute a precompile in the precompile set.
 	/// If the provided address is not a precompile, returns None.
-	fn execute<H: PrecompileHandle>(
+	fn execute(
 		&self,
-		handle: &mut H,
+		handle: &mut impl PrecompileHandle,
 		address: H160,
 		input: &[u8],
 		gas_limit: Option<u64>,
@@ -286,9 +286,9 @@ pub trait PrecompileSet {
 }
 
 impl PrecompileSet for () {
-	fn execute<H: PrecompileHandle>(
+	fn execute(
 		&self,
-		_: &mut H,
+		_: &mut impl PrecompileHandle,
 		_: H160,
 		_: &[u8],
 		_: Option<u64>,
@@ -314,9 +314,9 @@ pub type PrecompileFn =
 	fn(&[u8], Option<u64>, &Context, bool) -> Result<(PrecompileOutput, u64), PrecompileFailure>;
 
 impl PrecompileSet for BTreeMap<H160, PrecompileFn> {
-	fn execute<H: PrecompileHandle>(
+	fn execute(
 		&self,
-		handle: &mut H,
+		handle: &mut impl PrecompileHandle,
 		address: H160,
 		input: &[u8],
 		gas_limit: Option<u64>,

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -6,8 +6,8 @@ mod executor;
 mod memory;
 
 pub use self::executor::{
-	Accessed, PrecompileFailure, PrecompileFn, PrecompileOutput, PrecompileSet, StackExecutor,
-	StackExitKind, StackState, StackSubstateMetadata, PrecompileHandle,
+	Accessed, PrecompileFailure, PrecompileFn, PrecompileHandle, PrecompileOutput, PrecompileSet,
+	StackExecutor, StackExitKind, StackState, StackSubstateMetadata,
 };
 
 pub use self::memory::{MemoryStackAccount, MemoryStackState, MemoryStackSubstate};

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -7,7 +7,7 @@ mod memory;
 
 pub use self::executor::{
 	Accessed, PrecompileFailure, PrecompileFn, PrecompileOutput, PrecompileSet, StackExecutor,
-	StackExitKind, StackState, StackSubstateMetadata,
+	StackExitKind, StackState, StackSubstateMetadata, PrecompileHandle,
 };
 
 pub use self::memory::{MemoryStackAccount, MemoryStackState, MemoryStackSubstate};


### PR DESCRIPTION
Adds a `PrecompileHandle` trait allowing to perform subcalls and register gas and logs from a precompile.
Registering gas and logs with the handle provides better integration with gas and logs that could be emitted by the subcalls.
For that reason the `cost` and logs fields of `PrecompileOutput` are removed.