### PR TITLE
fix cargo doc error

### DIFF
--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -69,8 +69,8 @@ pub trait Handler {
 	/// (or set in `accessed_addresses` / `accessed_storage_keys` via an access list
 	/// transaction).
 	/// References:
-	/// * https://eips.ethereum.org/EIPS/eip-2929
-	/// * https://eips.ethereum.org/EIPS/eip-2930
+	/// * <https://eips.ethereum.org/EIPS/eip-2929>
+	/// * <https://eips.ethereum.org/EIPS/eip-2930>
 	fn is_cold(&self, address: H160, index: Option<H256>) -> bool;
 
 	/// Set storage value of address at index.


### PR DESCRIPTION
$ cargo doc --open

```shell
    Checking evm-runtime v0.35.0 (~/evm/runtime)
 Documenting evm-runtime v0.35.0 (~/evm/runtime)
    Checking evm-gasometer v0.35.0 (~/evm/gasometer)
error: this URL is not a hyperlink
  --> runtime/src/handler.rs:68:2
   |
68 | /     /// Checks if the address or (address, index) pair has been previously accessed
69 | |     /// (or set in `accessed_addresses` / `accessed_storage_keys` via an access list
70 | |     /// transaction).
71 | |     /// References:
72 | |     /// https://eips.ethereum.org/EIPS/eip-2929
73 | |     /// https://eips.ethereum.org/EIPS/eip-2930
   | |_______________________________________________^ help: use an automatic link instead: `<https://eips.ethereum.org/EIPS/eip-2929>`
   |
note: the lint level is defined here
  --> runtime/src/lib.rs:3:9
   |
3  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(rustdoc::bare_urls)]` implied by `#[deny(warnings)]`
   = note: bare URLs are not automatically turned into clickable links

error: this URL is not a hyperlink
  --> runtime/src/handler.rs:68:2
   |
68 | /     /// Checks if the address or (address, index) pair has been previously accessed
69 | |     /// (or set in `accessed_addresses` / `accessed_storage_keys` via an access list
70 | |     /// transaction).
71 | |     /// References:
72 | |     /// https://eips.ethereum.org/EIPS/eip-2929
73 | |     /// https://eips.ethereum.org/EIPS/eip-2930
   | |_______________________________________________^ help: use an automatic link instead: `<https://eips.ethereum.org/EIPS/eip-2930>`
   |
   = note: bare URLs are not automatically turned into clickable links
```