### PR TITLE
`ExitError` specify invalid opcode

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -127,9 +127,9 @@ pub enum ExitError {
 	/// Create init code exceeds limit (runtime).
 	#[cfg_attr(feature = "with-codec", codec(index = 7))]
 	CreateContractLimit,
-	/// Starting byte must not begin with 0xef. See [EIP-3541](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3541.md).
-	#[cfg_attr(feature = "with-codec", codec(index = 14))]
-	InvalidCode,
+	/// Invalid opcode during execution or starting byte is 0xef. See [EIP-3541](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3541.md).
+	#[cfg_attr(feature = "with-codec", codec(index = 15))]
+	InvalidCode(u8),
 
 	/// An opcode accesses external information, but the request is off offset
 	/// limit (runtime).

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -610,7 +610,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 			}
 		}
 
-		_ => GasCost::Invalid,
+		_ => return Err(ExitError::InvalidCode(opcode.0)),
 	};
 
 	let memory_cost = match opcode {

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -115,7 +115,7 @@ pub trait Handler {
 		stack: &Stack,
 	) -> Result<(), ExitError>;
 	/// Handle other unknown external opcodes.
-	fn other(&mut self, _opcode: Opcode, _stack: &mut Machine) -> Result<(), ExitError> {
-		Err(ExitError::OutOfGas)
+	fn other(&mut self, opcode: Opcode, _stack: &mut Machine) -> Result<(), ExitError> {
+		Err(ExitError::InvalidCode(opcode.0))
 	}
 }

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -648,7 +648,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		fn check_first_byte(config: &Config, code: &[u8]) -> Result<(), ExitError> {
 			if config.disallow_executable_format {
 				if let Some(0xef) = code.get(0) {
-					return Err(ExitError::InvalidCode);
+					return Err(ExitError::InvalidCode(0xef));
 				}
 			}
 			Ok(())


### PR DESCRIPTION
Return the opcode as part of `ExitError` when an invalid opcode is found.