### PR TITLE
Use saturating_mul in fee() calculation

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -583,7 +583,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 	/// Get fee needed for the current executor, given the price.
 	pub fn fee(&self, price: U256) -> U256 {
 		let used_gas = self.used_gas();
-		U256::from(used_gas) * price
+		U256::from(used_gas).saturating_mul(price)
 	}
 
 	/// Get account nonce.


### PR DESCRIPTION
This updates the `fee()` calculation to use saturating multiplication. It is otherwise possible for this fn to overflow with sufficiently large inputs.

A more disruptive alternative would be to convert return type to be an `Option<U256>` and return `None` upon overflow.