### PR TITLE
use no-std serde for primitive-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ with-codec = [
 ]
 with-serde = [
 	"serde",
-	"primitive-types/serde",
+	"primitive-types/impl-serde",
 	"evm-core/with-serde",
 	"ethereum/with-serde",
 ]


### PR DESCRIPTION
"std" is switched on with "primitive-types/serde". To avoid it, we can use "primitive-types/impl-serde" instead.