### PR TITLE
Address reservation hooks

### DIFF
--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -125,6 +125,10 @@ impl<'vicinity> Backend for MemoryBackend<'vicinity> {
 		self.state.contains_key(&address)
 	}
 
+	fn is_reserved(&self, _address: H160) -> bool {
+		false
+	}
+
 	fn basic(&self, address: H160) -> Basic {
 		self.state
 			.get(&address)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -75,6 +75,9 @@ pub trait Backend {
 
 	/// Whether account at address exists.
 	fn exists(&self, address: H160) -> bool;
+	/// Whether it is disallowed to deploy contract at the specified address.
+	/// CREATE on the specified address will fail with CreateCollision.
+	fn is_reserved(&self, address: H160) -> bool;
 	/// Get basic account information.
 	fn basic(&self, address: H160) -> Basic;
 	/// Get account code.

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -818,12 +818,10 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		self.enter_substate(gas_limit, false);
 
 		{
-			if self.code_size(address) != U256::zero() {
-				let _ = self.exit_substate(StackExitKind::Failed);
-				return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()));
-			}
-
-			if self.nonce(address) > U256::zero() {
+			if self.state.is_reserved(address)
+				|| self.code_size(address) != U256::zero()
+				|| self.nonce(address) > U256::zero()
+			{
 				let _ = self.exit_substate(StackExitKind::Failed);
 				return Capture::Exit((ExitError::CreateCollision.into(), None, Vec::new()));
 			}

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -448,6 +448,10 @@ impl<'backend, 'config, B: Backend> Backend for MemoryStackState<'backend, 'conf
 			.unwrap_or_else(|| self.backend.code(address))
 	}
 
+	fn is_reserved(&self, address: H160) -> bool {
+		self.backend.is_reserved(address)
+	}
+
 	fn storage(&self, address: H160, key: H256) -> H256 {
 		self.substate
 			.known_storage(address, key)


### PR DESCRIPTION
Allow address to be marked as reserved, deployments to reserved addresses will fail with CreateCollision.
