### PR TITLE
perf: minor optimization of byte opcode function

### DIFF
--- a/core/src/eval/bitwise.rs
+++ b/core/src/eval/bitwise.rs
@@ -43,16 +43,14 @@ pub fn not(op1: U256) -> U256 {
 pub fn byte(op1: U256, op2: U256) -> U256 {
 	let mut ret = U256::zero();
 
-	if op1 >= 32.into() {
-		return ret;
-	}
-
-	for i in 0..8 {
-		let o: usize = op1.as_usize();
-		let t = 255 - (7 - i + 8 * o);
-		let bit_mask = U256::one() << t;
-		let value = (op2 & bit_mask) >> t;
-		ret = ret.overflowing_add(value << i).0;
+	if op1 < 32.into() {
+		for i in 0..8 {
+			let o: usize = op1.as_usize();
+			let t = 255 - (7 - i + 8 * o);
+			let bit_mask = U256::one() << t;
+			let value = (op2 & bit_mask) >> t;
+			ret = ret.overflowing_add(value << i).0;
+		}
 	}
 
 	ret


### PR DESCRIPTION
I have added a minor optimization to the `BYTE` evaluator.

Essentially we can skip the for loop entirely if `op1 < 32`, and we only need to iterate up to 7, not 255.

So this brings it down from 256 iterations for each function call to either 0 or 8 iterations depending on the value of `op1`.