### PR TITLE
fix: double substate discard in eip-3860

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -404,7 +404,6 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 			// EIP-3860
 			if init_code.len() > limit {
 				self.state.metadata_mut().gasometer.fail();
-				let _ = self.exit_substate(StackExitKind::Failed);
 				return Err(ExitError::OutOfGas);
 			}
 			return self

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -54,8 +54,8 @@ impl<'config> MemoryStackSubstate<'config> {
 		&mut self.metadata
 	}
 
-	/// Deconstruct the executor, return state to be applied. Panic if the
-	/// executor is not in the top-level substate.
+	/// Deconstruct the memory stack substate, return state to be applied. Panic if the
+	/// substate is not in the top-level substate.
 	#[must_use]
 	pub fn deconstruct<B: Backend>(
 		mut self,

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -73,7 +73,8 @@ pub trait PrecompileHandle {
 }
 
 /// A set of precompiles.
-/// Checks of the provided address being in the precompile set should be
+///
+/// Checks if the provided address is in the precompile set. This should be
 /// as cheap as possible since it may be called often.
 pub trait PrecompileSet {
 	/// Tries to execute a precompile in the precompile set.


### PR DESCRIPTION
The initcode analysis introduced in [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) had a bug in the error path.

## Details

### More detail about the bug

The problem was that the current execution's memory stack substate [was discarded immediately in the error path](https://github.com/rust-blockchain/evm/blob/2e9c3b71f7b9ff241735f15145517d0627c469e6/src/executor/stack/executor.rs#L407), while the `transact_{call,create}` methods also attempted to discard the same substate in the [cleanup procedure](https://github.com/rust-blockchain/evm/blob/2e9c3b71f7b9ff241735f15145517d0627c469e6/src/executor/stack/executor.rs#L347), but because such a substate no longer existed and only the root substate remained, the executor would panic as it can't remove the root substate.

### Context - the test case that triggered the bug

The way this error surfaced was when the initial `StackExecutor::transact_{call,create}` executed code that contained a `CREATE/2` opcode which call `<StackExecutor as Handler>::create`.

Specifically, the `st_random` and `st_random2` tests were failing, e.g. the `randomStatetest307` test case contained code what would try to create a contract with an initcode size of 50k bytes that exceeded the initcode size limit and thus triggered the error path in the nested create call (`CREATE` opcode).