### PR TITLE
fix: cap nonce value at 2^64-1 as per EIP-2681 

### DIFF
--- a/benches/loop.rs
+++ b/benches/loop.rs
@@ -19,6 +19,7 @@ fn run_loop_contract() {
 		block_gas_limit: Default::default(),
 		chain_id: U256::one(),
 		block_base_fee_per_gas: U256::zero(),
+		block_randomness: None,
 	};
 
 	let mut state = BTreeMap::new();

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -155,6 +155,11 @@ pub enum ExitError {
 	/// Other normal errors.
 	#[cfg_attr(feature = "with-codec", codec(index = 13))]
 	Other(Cow<'static, str>),
+
+	/// Nonce reached maximum value of 2^64-1
+	/// https://eips.ethereum.org/EIPS/eip-2681
+	#[cfg_attr(feature = "with-codec", codec(index = 14))]
+	MaxNonce,
 }
 
 impl From<ExitError> for ExitReason {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -127,6 +127,7 @@ pub enum ExitError {
 	/// Create init code exceeds limit (runtime).
 	#[cfg_attr(feature = "with-codec", codec(index = 7))]
 	CreateContractLimit,
+
 	/// Invalid opcode during execution or starting byte is 0xef. See [EIP-3541](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3541.md).
 	#[cfg_attr(feature = "with-codec", codec(index = 15))]
 	InvalidCode(Opcode),

--- a/runtime/src/eval/mod.rs
+++ b/runtime/src/eval/mod.rs
@@ -40,7 +40,7 @@ pub fn eval<H: Handler>(state: &mut Runtime, opcode: Opcode, handler: &mut H) ->
 		Opcode::COINBASE => system::coinbase(state, handler),
 		Opcode::TIMESTAMP => system::timestamp(state, handler),
 		Opcode::NUMBER => system::number(state, handler),
-		Opcode::DIFFICULTY => system::difficulty(state, handler),
+		Opcode::DIFFICULTY => system::prevrandao(state, handler),
 		Opcode::GASLIMIT => system::gaslimit(state, handler),
 		Opcode::SLOAD => system::sload(state, handler),
 		Opcode::SSTORE => system::sstore(state, handler),

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -185,6 +185,15 @@ pub fn difficulty<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> 
 	Control::Continue
 }
 
+pub fn prevrandao<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
+	if let Some(rand) = handler.block_randomness() {
+		push!(runtime, rand);
+		Control::Continue
+	} else {
+		difficulty(runtime, handler)
+	}
+}
+
 pub fn gaslimit<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	push_u256!(runtime, handler.block_gas_limit());
 	Control::Continue

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -54,6 +54,8 @@ pub trait Handler {
 	fn block_timestamp(&self) -> U256;
 	/// Get environmental block difficulty.
 	fn block_difficulty(&self) -> U256;
+	/// Get environmental block randomness.
+	fn block_randomness(&self) -> Option<H256>;
 	/// Get environmental gas limit.
 	fn block_gas_limit(&self) -> U256;
 	/// Environmental block base fee.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -409,6 +409,11 @@ impl Config {
 		Self::config_with_derived_values(DerivedConfigInputs::london())
 	}
 
+	/// The Merge (Paris) hard fork configuration.
+	pub const fn merge() -> Config {
+		Self::config_with_derived_values(DerivedConfigInputs::merge())
+	}
+
 	/// Shanghai hard fork configuration.
 	pub const fn shanghai() -> Config {
 		Self::config_with_derived_values(DerivedConfigInputs::shanghai())
@@ -522,6 +527,20 @@ impl DerivedConfigInputs {
 	}
 
 	const fn london() -> Self {
+		Self {
+			gas_storage_read_warm: 100,
+			gas_sload_cold: 2100,
+			gas_access_list_storage_key: 1900,
+			decrease_clears_refund: true,
+			has_base_fee: true,
+			has_push0: false,
+			disallow_executable_format: true,
+			warm_coinbase_address: false,
+			max_initcode_size: None,
+		}
+	}
+
+	const fn merge() -> Self {
 		Self {
 			gas_storage_read_warm: 100,
 			gas_sload_cold: 2100,

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -31,6 +31,11 @@ pub struct MemoryVicinity {
 	pub block_gas_limit: U256,
 	/// Environmental base fee per gas.
 	pub block_base_fee_per_gas: U256,
+	/// Environmental randomness.
+	///
+	/// In Ethereum, this is the randomness beacon provided by the beacon
+	/// chain and is only enabled post Merge.
+	pub block_randomness: Option<H256>,
 }
 
 /// Account information of a memory backend.
@@ -109,6 +114,9 @@ impl<'vicinity> Backend for MemoryBackend<'vicinity> {
 	}
 	fn block_difficulty(&self) -> U256 {
 		self.vicinity.block_difficulty
+	}
+	fn block_randomness(&self) -> Option<H256> {
+		self.vicinity.block_randomness
 	}
 	fn block_gas_limit(&self) -> U256 {
 		self.vicinity.block_gas_limit

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -47,7 +47,7 @@ pub struct MemoryVicinity {
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemoryAccount {
 	/// Account nonce.
-	pub nonce: U256,
+	pub nonce: u64,
 	/// Account balance.
 	pub balance: U256,
 	/// Full account storage.
@@ -210,8 +210,7 @@ impl<'vicinity> ApplyBackend for MemoryBackend<'vicinity> {
 						}
 
 						account.balance == U256::zero()
-							&& account.nonce == U256::zero()
-							&& account.code.is_empty()
+							&& account.nonce == 0 && account.code.is_empty()
 					};
 
 					if is_empty && delete_empty {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -20,7 +20,7 @@ pub struct Basic {
 	/// Account balance.
 	pub balance: U256,
 	/// Account nonce.
-	pub nonce: U256,
+	pub nonce: u64,
 }
 
 pub use ethereum::Log;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -66,6 +66,8 @@ pub trait Backend {
 	fn block_timestamp(&self) -> U256;
 	/// Environmental block difficulty.
 	fn block_difficulty(&self) -> U256;
+	/// Get environmental block randomness.
+	fn block_randomness(&self) -> Option<H256>;
 	/// Environmental block gas limit.
 	fn block_gas_limit(&self) -> U256;
 	/// Environmental block base fee.

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -304,7 +304,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 	/// Execute using Runtimes on the call_stack until it returns.
 	fn execute_with_call_stack(
 		&mut self,
-		call_stack: &mut Vec<TaggedRuntime>,
+		call_stack: &mut Vec<TaggedRuntime<'_>>,
 	) -> (ExitReason, Option<H160>, Vec<u8>) {
 		// This `interrupt_runtime` is used to pass the runtime obtained from the
 		// `Capture::Trap` branch in the match below back to the top of the call stack.
@@ -1107,6 +1107,9 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 	}
 	fn block_difficulty(&self) -> U256 {
 		self.state.block_difficulty()
+	}
+	fn block_randomness(&self) -> Option<H256> {
+		self.state.block_randomness()
 	}
 	fn block_gas_limit(&self) -> U256 {
 		self.state.block_gas_limit()

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -421,6 +421,9 @@ impl<'backend, 'config, B: Backend> Backend for MemoryStackState<'backend, 'conf
 	fn block_difficulty(&self) -> U256 {
 		self.backend.block_difficulty()
 	}
+	fn block_randomness(&self) -> Option<H256> {
+		self.backend.block_randomness()
+	}
 	fn block_gas_limit(&self) -> U256 {
 		self.backend.block_gas_limit()
 	}


### PR DESCRIPTION
Since geth and other implementations were implicitly capping the nonce value at 2^64-1, EIP-2681 formalized it. Sputnik wasn't following this spec as a nonce value was of type U256, which caused a recently added ethereum test case to fail.

NOTE: https://github.com/rust-blockchain/evm/pull/162 should be merged first as this builds on that PR.