### PR TITLE
External cost recorder `with-substrate` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,8 +24,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-    - name: Build for feature
+    - name: Build for feature (tracing)
       run: cargo build --features tracing --verbose
+    - name: Build for feature (with-substrate)
+      run: cargo build --features with-substrate --verbose
     - name: Run tests
       run: cargo test --verbose
   jsontests:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ with-serde = [
 	"evm-core/with-serde",
 	"ethereum/with-serde",
 ]
+with-substrate = []
 tracing = [
 	"environmental",
 	"evm-gasometer/tracing",

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -32,8 +32,8 @@ impl Stack {
 
 	#[inline]
 	/// Whether the stack is empty.
-	pub fn is_empty(&self) -> bool {
-		self.data.is_empty()
+	pub fn is_empty(&self) -> Result<bool, ExitError> {
+		Ok(self.data.is_empty())
 	}
 
 	#[inline]

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -507,7 +507,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 				value: U256::from_big_endian(&stack.peek(2)?[..]),
 				gas: U256::from_big_endian(&stack.peek(0)?[..]),
 				target_is_cold: handler.is_cold(target, None)?,
-				target_exists: handler.exists(target),
+				target_exists: handler.exists(target)?,
 			}
 		}
 		Opcode::STATICCALL => {
@@ -516,7 +516,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 			GasCost::StaticCall {
 				gas: U256::from_big_endian(&stack.peek(0)?[..]),
 				target_is_cold: handler.is_cold(target, None)?,
-				target_exists: handler.exists(target),
+				target_exists: handler.exists(target)?,
 			}
 		}
 		Opcode::SHA3 => GasCost::Sha3 {
@@ -550,7 +550,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 			GasCost::DelegateCall {
 				gas: U256::from_big_endian(&stack.peek(0)?[..]),
 				target_is_cold: handler.is_cold(target, None)?,
-				target_exists: handler.exists(target),
+				target_exists: handler.exists(target)?,
 			}
 		}
 		Opcode::DELEGATECALL => GasCost::Invalid(opcode),
@@ -603,7 +603,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 			GasCost::Suicide {
 				value: handler.balance(address),
 				target_is_cold: handler.is_cold(target, None)?,
-				target_exists: handler.exists(target),
+				target_exists: handler.exists(target)?,
 				already_removed: handler.deleted(address),
 			}
 		}
@@ -617,7 +617,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 				value: U256::from_big_endian(&stack.peek(2)?[..]),
 				gas: U256::from_big_endian(&stack.peek(0)?[..]),
 				target_is_cold: handler.is_cold(target, None)?,
-				target_exists: handler.exists(target),
+				target_exists: handler.exists(target)?,
 			}
 		}
 

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -90,16 +90,24 @@ pub fn base_fee<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	Control::Continue
 }
 
-pub fn extcodesize<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
+pub fn extcodesize<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
 	pop!(runtime, address);
-	push_u256!(runtime, handler.code_size(address.into()));
+	let code_size = match handler.code_size(address.into()) {
+		Ok(v) => v,
+		Err(e) => return Control::Exit(e.into()),
+	};
+	push_u256!(runtime, code_size);
 
 	Control::Continue
 }
 
-pub fn extcodehash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
+pub fn extcodehash<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
 	pop!(runtime, address);
-	push!(runtime, handler.code_hash(address.into()));
+	let code_hash = match handler.code_hash(address.into()) {
+		Ok(v) => v,
+		Err(e) => return Control::Exit(e.into()),
+	};
+	push!(runtime, code_hash);
 
 	Control::Continue
 }

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -28,9 +28,9 @@ pub trait Handler {
 	/// Get balance of address.
 	fn balance(&self, address: H160) -> U256;
 	/// Get code size of address.
-	fn code_size(&self, address: H160) -> U256;
+	fn code_size(&mut self, address: H160) -> Result<U256, ExitError>;
 	/// Get code hash of address.
-	fn code_hash(&self, address: H160) -> H256;
+	fn code_hash(&mut self, address: H160) -> Result<H256, ExitError>;
 	/// Get code of address.
 	fn code(&self, address: H160) -> Vec<u8>;
 	/// Get storage value of address at index.

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -32,7 +32,7 @@ pub trait Handler {
 	/// Get code hash of address.
 	fn code_hash(&mut self, address: H160) -> Result<H256, ExitError>;
 	/// Get code of address.
-	fn code(&self, address: H160) -> Vec<u8>;
+	fn code(&mut self, address: H160) -> Result<Vec<u8>, ExitError>;
 	/// Get storage value of address at index.
 	fn storage(&self, address: H160, index: H256) -> H256;
 	/// Get original storage value of address at index.
@@ -62,7 +62,7 @@ pub trait Handler {
 	fn chain_id(&self) -> U256;
 
 	/// Check whether an address exists.
-	fn exists(&self, address: H160) -> bool;
+	fn exists(&mut self, address: H160) -> Result<bool, ExitError>;
 	/// Check whether an address has already been deleted.
 	fn deleted(&self, address: H160) -> bool;
 	/// Checks if the address or (address, index) pair has been previously accessed

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -2,6 +2,7 @@ use super::{Apply, ApplyBackend, Backend, Basic, Log};
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use primitive_types::{H160, H256, U256};
+use crate::ExitError;
 
 /// Vicinity value of a memory backend.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -135,11 +136,11 @@ impl<'vicinity> Backend for MemoryBackend<'vicinity> {
 			.unwrap_or_default()
 	}
 
-	fn code(&self, address: H160) -> Vec<u8> {
-		self.state
+	fn code(&mut self, address: H160) -> Result<Vec<u8>, ExitError> {
+		Ok(self.state
 			.get(&address)
 			.map(|v| v.code.clone())
-			.unwrap_or_default()
+			.unwrap_or_default())
 	}
 
 	fn storage(&self, address: H160, index: H256) -> H256 {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,7 +5,7 @@
 mod memory;
 
 pub use self::memory::{MemoryAccount, MemoryBackend, MemoryVicinity};
-
+use crate::ExitError;
 use alloc::vec::Vec;
 use primitive_types::{H160, H256, U256};
 
@@ -50,7 +50,7 @@ pub enum Apply<I> {
 }
 
 /// EVM backend.
-#[auto_impl::auto_impl(&, Arc, Box)]
+//#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait Backend {
 	/// Gas price. Unused for London.
 	fn gas_price(&self) -> U256;
@@ -78,7 +78,7 @@ pub trait Backend {
 	/// Get basic account information.
 	fn basic(&self, address: H160) -> Basic;
 	/// Get account code.
-	fn code(&self, address: H160) -> Vec<u8>;
+	fn code(&mut self, address: H160) -> Result<Vec<u8>, ExitError>;
 	/// Get storage value of address at index.
 	fn storage(&self, address: H160, index: H256) -> H256;
 	/// Get original storage value of address at index, if available.

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -487,7 +487,6 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		if let Some(limit) = self.config.max_initcode_size {
 			if init_code.len() > limit {
 				self.state.metadata_mut().gasometer.fail();
-				let _ = self.exit_substate(StackExitKind::Failed);
 				return emit_exit!(ExitError::CreateContractLimit.into(), Vec::new());
 			}
 		}

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -230,10 +230,6 @@ pub trait StackState<'config>: Backend {
 		Ok(H256::from_slice(Keccak256::digest(&self.code(address)).as_slice()))
 	}
 	
-	fn record_external_static_opcode_cost(&mut self, _opcode: Opcode) -> Result<(), ExitError> {
-		Ok(())
-	}
-	
 	fn record_external_dynamic_opcode_cost(&mut self, _opcode: Opcode, _gas_cost: GasCost, _target: StorageTarget) -> Result<(), ExitError> {
 		Ok(())
 	}
@@ -1271,7 +1267,6 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Handler
 
 		if let Some(cost) = gasometer::static_opcode_cost(opcode) {
 			self.state.metadata_mut().gasometer.record_cost(cost)?;
-			self.state.record_external_static_opcode_cost(opcode)?;
 		} else {
 			let is_static = self.state.metadata().is_static;
 			let (gas_cost, target, memory_cost) = gasometer::dynamic_opcode_cost(

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -447,7 +447,6 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		if let Some(limit) = self.config.max_initcode_size {
 			if init_code.len() > limit {
 				self.state.metadata_mut().gasometer.fail();
-				let _ = self.exit_substate(StackExitKind::Failed);
 				return emit_exit!(ExitError::CreateContractLimit.into(), Vec::new());
 			}
 		}

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -240,9 +240,7 @@ pub trait StackState<'config>: Backend {
 	}
 
 	#[cfg(feature = "with-substrate")]
-	fn refund_external_cost(&mut self, _ref_time: Option<u64>, _proof_size: Option<u64>) -> Result<(), ExitError> {
-		Ok(())
-	}
+	fn refund_external_cost(&mut self, _ref_time: Option<u64>, _proof_size: Option<u64>) {}
 }
 
 /// Stack-based executor.
@@ -1405,7 +1403,7 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 	fn refund_external_cost(&mut self, ref_time: Option<u64>, proof_size: Option<u64>) {
 		self.executor
 			.state
-			.refund_external_cost(ref_time, proof_size)
+			.refund_external_cost(ref_time, proof_size);
 	}
 
 	/// Retreive the remaining gas.

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -235,7 +235,12 @@ pub trait StackState<'config>: Backend {
 	}
 
 	#[cfg(feature = "with-substrate")]
-	fn record_external_cost(&mut self, _ref_time: u64, _proof_size: u64) -> Result<(), ExitError> {
+	fn record_external_cost(&mut self, _ref_time: Option<u64>, _proof_size: Option<u64>) -> Result<(), ExitError> {
+		Ok(())
+	}
+
+	#[cfg(feature = "with-substrate")]
+	fn refund_external_cost(&mut self, _ref_time: Option<u64>, _proof_size: Option<u64>) -> Result<(), ExitError> {
 		Ok(())
 	}
 }
@@ -1388,10 +1393,19 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 	}
 
 	#[cfg(feature = "with-substrate")]
-	fn record_external_cost(&mut self, ref_time: u64, proof_size: u64) -> Result<(), ExitError> {
+	/// Record Substrate specific cost.
+	fn record_external_cost(&mut self, ref_time: Option<u64>, proof_size: Option<u64>) -> Result<(), ExitError> {
 		self.executor
 			.state
 			.record_external_cost(ref_time, proof_size)
+	}
+
+	#[cfg(feature = "with-substrate")]
+	/// Refund Substrate specific cost.
+	fn refund_external_cost(&mut self, ref_time: Option<u64>, proof_size: Option<u64>) {
+		self.executor
+			.state
+			.refund_external_cost(ref_time, proof_size)
 	}
 
 	/// Retreive the remaining gas.

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -530,8 +530,9 @@ impl<'backend, 'config, B: Backend> StackState<'config> for MemoryStackState<'ba
 		self.substate.set_deleted(address)
 	}
 
-	fn set_code(&mut self, address: H160, code: Vec<u8>) {
-		self.substate.set_code(address, code, self.backend)
+	fn set_code(&mut self, address: H160, code: Vec<u8>) -> Result<(), ExitError> {
+		self.substate.set_code(address, code, self.backend);
+		Ok(())
 	}
 
 	fn transfer(&mut self, transfer: Transfer) -> Result<(), ExitError> {

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -50,6 +50,10 @@ pub trait PrecompileHandle {
 	/// Record cost to the Runtime gasometer.
 	fn record_cost(&mut self, cost: u64) -> Result<(), ExitError>;
 
+	#[cfg(feature = "with-substrate")]
+	/// Record Substrate specific cost.
+	fn record_external_cost(&mut self, ref_time: u64, proof_size: u64) -> Result<(), ExitError>;
+
 	/// Retreive the remaining gas.
 	fn remaining_gas(&self) -> u64;
 

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -52,7 +52,11 @@ pub trait PrecompileHandle {
 
 	#[cfg(feature = "with-substrate")]
 	/// Record Substrate specific cost.
-	fn record_external_cost(&mut self, ref_time: u64, proof_size: u64) -> Result<(), ExitError>;
+	fn record_external_cost(&mut self, ref_time: Option<u64>, proof_size: Option<u64>) -> Result<(), ExitError>;
+
+	#[cfg(feature = "with-substrate")]
+	/// Refund Substrate specific cost.
+	fn refund_external_cost(&mut self, ref_time: Option<u64>, proof_size: Option<u64>);
 
 	/// Retreive the remaining gas.
 	fn remaining_gas(&self) -> u64;


### PR DESCRIPTION
This PR proposes adding 3 new methods to `StackState` trait (and 2 additional counterparts in `PrecompileHandle`) behind a `with-substrate` feature flag. This change is forced by additional resource restrictions in [parachains](https://polkadot.network/features/parachains/) and leaves the native gasometer logic and code **totally unchanged**.

With this new interface implementors can have a _capacity_ for any required _metric_ in the `Backend`. This way, prior to executing any `Opcode` (in `pre_validate`), there is an attempt to record this new external cost(s), and much like in the case of the gasometer, it will proceed with the Opcode execution or fail (`OutOfGas`) if the capacity for the external metric is exhausted.

As a whole, this PR is proposed in favor of alternative designs that would support this type of functionality, like for example being generic over the `Gas` type in the native gasometer. Those proposals were preliminarily discarded for being too intrusive for the evm code, given this is not an standard feature and can be solved in the `Backend`.

The methods introduced in `StackState` are:

- `record_external_dynamic_opcode_cost`: meant to be called prior to executing an Opcode (`pre_validate`). Calculates the amount of external resources needed for the given Opcode, and records the cost.
- `record_external_cost`: meant to be called from `record_external_dynamic_opcode_cost` implementation and from `PrecompileHandle` implementor. Records a cost (deducts an amount from the resource pool).
- `refund_external_cost`: meant to be called from `record_external_dynamic_opcode_cost` implementation and from `PrecompileHandle` implementor. Refunds a cost (sums an amount from the resource pool).

The methods introduced in `PrecompileHandle` are:

- `record_external_cost`: meant to interface with `StackState`.
- `refund_external_cost`: meant to interface with `StackState`.

In addition to the feature-specific additions, in this PR there are some additional changes included that are needed to properly fail the gasometer in case any of this external resources are exhausted.
