### PR TITLE
Move record_external_operation to StackState trait

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,7 +5,6 @@
 mod memory;
 
 pub use self::memory::{MemoryAccount, MemoryBackend, MemoryVicinity};
-use crate::ExitError;
 use alloc::vec::Vec;
 use primitive_types::{H160, H256, U256};
 /// Basic account information.
@@ -49,7 +48,7 @@ pub enum Apply<I> {
 }
 
 /// EVM backend.
-//#[auto_impl::auto_impl(&, Arc, Box)]
+#[auto_impl::auto_impl(&, Arc, Box)]
 pub trait Backend {
 	/// Gas price. Unused for London.
 	fn gas_price(&self) -> U256;
@@ -84,13 +83,6 @@ pub trait Backend {
 	fn storage(&self, address: H160, index: H256) -> H256;
 	/// Get original storage value of address at index, if available.
 	fn original_storage(&self, address: H160, index: H256) -> Option<H256>;
-
-	fn record_external_operation(
-		&mut self,
-		_op: crate::ExternalOperation,
-	) -> Result<(), ExitError> {
-		Ok(())
-	}
 }
 
 /// EVM backend that can apply changes.

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -230,6 +230,13 @@ pub trait StackState<'config>: Backend {
 		H256::from_slice(Keccak256::digest(self.code(address)).as_slice())
 	}
 
+	fn record_external_operation(
+		&mut self,
+		_op: crate::ExternalOperation,
+	) -> Result<(), ExitError> {
+		Ok(())
+	}
+
 	fn record_external_dynamic_opcode_cost(
 		&mut self,
 		_opcode: Opcode,


### PR DESCRIPTION
This allows the auto_impl to be uncommented.