### PR TITLE
Add support for a gas-based storage limit

### DIFF
--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -1,4 +1,4 @@
-use primitive_types::H160;
+use primitive_types::{H160, U256};
 
 /// Operations for recording external costs
 pub enum ExternalOperation {
@@ -8,6 +8,6 @@ pub enum ExternalOperation {
 	AddressCodeRead(H160),
 	/// Basic check for account emptiness. Fixed size.
 	IsEmpty,
-	/// Writing to storage. Fixed size.
-	Write,
+	/// Writing to storage (Number of bytes written).
+	Write(U256),
 }

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -250,6 +250,7 @@ pub trait StackState<'config>: Backend {
 		&mut self,
 		_ref_time: Option<u64>,
 		_proof_size: Option<u64>,
+		_storage_growth: Option<u64>,
 	) -> Result<(), ExitError> {
 		Ok(())
 	}
@@ -1464,10 +1465,11 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 		&mut self,
 		ref_time: Option<u64>,
 		proof_size: Option<u64>,
+		storage_growth: Option<u64>,
 	) -> Result<(), ExitError> {
 		self.executor
 			.state
-			.record_external_cost(ref_time, proof_size)
+			.record_external_cost(ref_time, proof_size, storage_growth)
 	}
 
 	/// Refund Substrate specific cost.

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1009,10 +1009,9 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 				{
 					Ok(()) => {
 						let exit_result = self.exit_substate(StackExitKind::Succeeded);
-
-						if let Err(e) =
-							self.record_external_operation(crate::ExternalOperation::Write)
-						{
+						if let Err(e) = self.record_external_operation(
+							crate::ExternalOperation::Write(U256::from(out.len())),
+						) {
 							return (e.into(), None, Vec::new());
 						}
 						self.state.set_code(address, out);

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -55,6 +55,7 @@ pub trait PrecompileHandle {
 		&mut self,
 		ref_time: Option<u64>,
 		proof_size: Option<u64>,
+		storage_growth: Option<u64>,
 	) -> Result<(), ExitError>;
 
 	/// Refund Substrate specific cost.


### PR DESCRIPTION
This PR introduces some minor changes that are needed to support introducing a new gas-based storage limit here https://github.com/paritytech/frontier/pull/1142.

Changes introduced:
- Add a U256 field to the `ExternalOperation::Write` variant that will be used to communicate the number of bytes written.
- Add `storage_growth` attribute to `record_external_cost` function to support recording of storage growth with precompiles.