### PR TITLE
Precompile used gas

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1513,4 +1513,9 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 	fn gas_limit(&self) -> Option<u64> {
 		self.gas_limit
 	}
+
+	// Retrieve the used gas.
+	fn used_gas(&self) -> u64 {
+		self.executor.used_gas()
+	}
 }

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1479,7 +1479,7 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 			.refund_external_cost(ref_time, proof_size);
 	}
 
-	/// Retreive the remaining gas.
+	/// Retrieve the remaining gas.
 	fn remaining_gas(&self) -> u64 {
 		self.executor.state.metadata().gasometer.gas()
 	}
@@ -1489,17 +1489,17 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 		Handler::log(self.executor, address, topics, data)
 	}
 
-	/// Retreive the code address (what is the address of the precompile being called).
+	/// Retrieve the code address (what is the address of the precompile being called).
 	fn code_address(&self) -> H160 {
 		self.code_address
 	}
 
-	/// Retreive the input data the precompile is called with.
+	/// Retrieve the input data the precompile is called with.
 	fn input(&self) -> &[u8] {
 		self.input
 	}
 
-	/// Retreive the context in which the precompile is executed.
+	/// Retrieve the context in which the precompile is executed.
 	fn context(&self) -> &Context {
 		self.context
 	}
@@ -1509,7 +1509,7 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 		self.is_static
 	}
 
-	/// Retreive the gas limit of this call.
+	/// Retrieve the gas limit of this call.
 	fn gas_limit(&self) -> Option<u64> {
 		self.gas_limit
 	}

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -61,25 +61,25 @@ pub trait PrecompileHandle {
 	/// Refund Substrate specific cost.
 	fn refund_external_cost(&mut self, ref_time: Option<u64>, proof_size: Option<u64>);
 
-	/// Retreive the remaining gas.
+	/// Retrieve the remaining gas.
 	fn remaining_gas(&self) -> u64;
 
 	/// Record a log.
 	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) -> Result<(), ExitError>;
 
-	/// Retreive the code address (what is the address of the precompile being called).
+	/// Retrieve the code address (what is the address of the precompile being called).
 	fn code_address(&self) -> H160;
 
-	/// Retreive the input data the precompile is called with.
+	/// Retrieve the input data the precompile is called with.
 	fn input(&self) -> &[u8];
 
-	/// Retreive the context in which the precompile is executed.
+	/// Retrieve the context in which the precompile is executed.
 	fn context(&self) -> &Context;
 
 	/// Is the precompile call is done statically.
 	fn is_static(&self) -> bool;
 
-	/// Retreive the gas limit of this call.
+	/// Retrieve the gas limit of this call.
 	fn gas_limit(&self) -> Option<u64>;
 
 	/// Retrieve the gas used.

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -81,6 +81,9 @@ pub trait PrecompileHandle {
 
 	/// Retreive the gas limit of this call.
 	fn gas_limit(&self) -> Option<u64>;
+
+	/// Retrieve the gas used.
+	fn used_gas(&self) -> u64;
 }
 
 /// A set of precompiles.


### PR DESCRIPTION
A set of changes that were useful for us to implement a precompile that returns gas usage.

Changes:
- adds `fn used_gas(&self) -> u64;`  to `PrecompileHandle` to support querying used_gas in precompiles
- propagates the "parent" `used_gas` into the Precompile (since precompile uses its own gasometer that starts at 0)
- minor typo fix `Retreive -> Retrieve`

Hope that none of these are too controversial.