### PR TITLE
No need to store exit reasons or return ranges

### DIFF
--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -213,7 +213,7 @@ pub fn ret<S>(state: &mut Machine<S>) -> Control {
 	trace_op!("Return");
 	pop_u256!(state, start, len);
 	try_or_fail!(state.memory.resize_offset(start, len));
-	state.return_range = start..(start + len);
+	state.memory.resize_to_range(start..(start + len));
 	Control::Exit(ExitSucceed::Returned.into())
 }
 
@@ -222,6 +222,6 @@ pub fn revert<S>(state: &mut Machine<S>) -> Control {
 	trace_op!("Revert");
 	pop_u256!(state, start, len);
 	try_or_fail!(state.memory.resize_offset(start, len));
-	state.return_range = start..(start + len);
+	state.memory.resize_to_range(start..(start + len));
 	Control::Exit(ExitRevert::Reverted.into())
 }


### PR DESCRIPTION
This PR changes several things related to positions and return values:

* There's no need to store exit reasons inside `Machine`. We thus only need a bare `usize` for the position.
* For return values, we can directly "shrink" the memory struct down to the scope. All other things inside the memory are irrelevant once the VM exits. The algorithm can still use massive improvements.