### PR TITLE
Implement Etable::wrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ tracing = [
 	"evm-gasometer/tracing",
 ]
 force-debug = [
-	"evm-interpreter/force-debug",
 	"evm-gasometer/force-debug",
 ]
 

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -39,4 +39,3 @@ with-serde = [
 	"serde",
 	"primitive-types/impl-serde",
 ]
-force-debug = []

--- a/interpreter/src/eval/macros.rs
+++ b/interpreter/src/eval/macros.rs
@@ -1,13 +1,3 @@
-#[cfg(feature = "force-debug")]
-macro_rules! trace_op {
-	($($arg:tt)*) => (log::trace!(target: "evm", "OpCode {}", format_args!($($arg)*)));
-}
-
-#[cfg(not(feature = "force-debug"))]
-macro_rules! trace_op {
-	($($arg:tt)*) => {};
-}
-
 macro_rules! try_or_fail {
 	( $e:expr ) => {
 		match $e {
@@ -68,7 +58,6 @@ macro_rules! op1_u256_fn {
 		pop_u256!($machine, op1);
 		let ret = $op(op1);
 		push_u256!($machine, ret);
-		trace_op!("{} {}: {}", stringify!($op), op1, ret);
 
 		Control::Continue
 	}};
@@ -79,7 +68,6 @@ macro_rules! op2_u256_bool_ref {
 		pop_u256!($machine, op1, op2);
 		let ret = op1.$op(&op2);
 		push_u256!($machine, if ret { U256::one() } else { U256::zero() });
-		trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 		Control::Continue
 	}};
@@ -90,7 +78,6 @@ macro_rules! op2_u256 {
 		pop_u256!($machine, op1, op2);
 		let ret = op1.$op(op2);
 		push_u256!($machine, ret);
-		trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 		Control::Continue
 	}};
@@ -101,7 +88,6 @@ macro_rules! op2_u256_tuple {
 		pop_u256!($machine, op1, op2);
 		let (ret, ..) = op1.$op(op2);
 		push_u256!($machine, ret);
-		trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 		Control::Continue
 	}};
@@ -112,7 +98,6 @@ macro_rules! op2_u256_fn {
 		pop_u256!($machine, op1, op2);
 		let ret = $op(op1, op2);
 		push_u256!($machine, ret);
-		trace_op!("{} {}, {}: {}", stringify!($op), op1, op2, ret);
 
 		Control::Continue
 	}};
@@ -123,7 +108,6 @@ macro_rules! op3_u256_fn {
 		pop_u256!($machine, op1, op2, op3);
 		let ret = $op(op1, op2, op3);
 		push_u256!($machine, ret);
-		trace_op!("{} {}, {}, {}: {}", stringify!($op), op1, op2, op3, ret);
 
 		Control::Continue
 	}};

--- a/interpreter/tests/performance.rs
+++ b/interpreter/tests/performance.rs
@@ -1,5 +1,7 @@
-use evm_core::{Capture, ExitSucceed, Machine};
+use evm_interpreter::{Capture, ExitSucceed, Machine, Etable};
 use std::rc::Rc;
+
+static ETABLE: Etable<(), ()> = Etable::core();
 
 macro_rules! ret_test {
 	( $name:ident, $code:expr, $data:expr, $ret:expr ) => {
@@ -8,9 +10,9 @@ macro_rules! ret_test {
 			let code = hex::decode($code).unwrap();
 			let data = hex::decode($data).unwrap();
 
-			let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000);
-			assert_eq!(vm.run(), Capture::Exit(ExitSucceed::Returned.into()));
-			assert_eq!(vm.return_value(), hex::decode($ret).unwrap());
+			let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000, ());
+			assert_eq!(vm.run(&mut (), &ETABLE), Capture::Exit(Ok(ExitSucceed::Returned.into())));
+			assert_eq!(vm.into_retbuf(), hex::decode($ret).unwrap());
 		}
 	};
 }

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -1,0 +1,26 @@
+use evm_interpreter::{Capture, ExitSucceed, Machine, Etable};
+use std::rc::Rc;
+
+const CODE1: &str = "60e060020a6000350480632839e92814601e57806361047ff414603457005b602a6004356024356047565b8060005260206000f35b603d6004356099565b8060005260206000f35b600082600014605457605e565b8160010190506093565b81600014606957607b565b60756001840360016047565b90506093565b609060018403608c85600186036047565b6047565b90505b92915050565b6000816000148060a95750816001145b60b05760b7565b81905060cf565b60c1600283036099565b60cb600184036099565b0190505b91905056";
+const DATA1: &str = "2839e92800000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000001";
+const RET1: &str = "000000000000000000000000000000000000000000000000000000000000000d";
+
+#[test]
+fn etable_wrap() {
+	let code = hex::decode(&CODE1).unwrap();
+	let data = hex::decode(&DATA1).unwrap();
+
+	let wrapped_etable = Etable::core().wrap(|f, opcode_t| {
+		move |machine, handle, opcode, position| {
+			assert_eq!(opcode_t, opcode);
+			println!("opcode: {:?}", opcode);
+			f(machine, handle, opcode, position)
+		}
+	});
+
+	let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000, ());
+	let result = vm.run(&mut (), &wrapped_etable);
+	assert_eq!(result, Capture::Exit(Ok(ExitSucceed::Returned.into())));
+	assert_eq!(vm.into_retbuf(), hex::decode(&RET1).unwrap());
+}
+


### PR DESCRIPTION
Support both static fn pointers and closures for `Etable`, thus making `Etable::wrap` work.

This will be the preferred tracing / debugging method in the future, and thus we're removing all the `force-debug` / `trace_op` code.