### PR TITLE
Improve trapping design

### DIFF
--- a/interpreter/src/error.rs
+++ b/interpreter/src/error.rs
@@ -1,19 +1,6 @@
 use crate::Opcode;
 use alloc::borrow::Cow;
 
-/// Trap which indicates that an `ExternalOpcode` has to be handled.
-pub type Trap = Opcode;
-
-/// Capture represents the result of execution.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Capture<E, T> {
-	/// The machine has exited. It cannot be executed again.
-	Exit(E),
-	/// The machine has trapped. It is waiting for external information, and can
-	/// be executed again.
-	Trap(T),
-}
-
 pub type ExitResult = Result<ExitSucceed, ExitError>;
 
 /// Exit reason.

--- a/interpreter/src/eval/mod.rs
+++ b/interpreter/src/eval/mod.rs
@@ -5,21 +5,34 @@ mod bitwise;
 mod misc;
 mod system;
 
-use crate::{ExitException, ExitResult, ExitSucceed, Handler, Machine, Opcode, RuntimeState, Trap};
+use crate::{
+	ExitException, ExitResult, ExitSucceed, Handler, Machine, Opcode, RuntimeState,
+	RuntimeTrapData, Trap,
+};
 use core::marker::PhantomData;
 use core::ops::{BitAnd, BitOr, BitXor, Deref, DerefMut};
 use primitive_types::{H256, U256};
 
+/// Control state.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum Control<Td> {
+	Continue,
+	ContinueN(usize),
+	Exit(ExitResult),
+	Jump(usize),
+	Trap(Td),
+}
+
 /// Evaluation function type.
-pub type Efn<S, H> = fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control;
+pub type Efn<S, H, Td> = fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Td>;
 
 /// The evaluation table for the EVM.
-pub struct Etable<S, H, F = Efn<S, H>>([F; 256], PhantomData<(S, H)>);
+pub struct Etable<S, H, Tr: Trap<S>, F = Efn<S, H, <Tr as Trap<S>>::Data>>(
+	[F; 256],
+	PhantomData<(S, H, Tr)>,
+);
 
-/// Runtime table.
-pub type RuntimeEtable<H, F = Efn<RuntimeState, H>> = Etable<RuntimeState, H, F>;
-
-impl<S, H, F> Deref for Etable<S, H, F> {
+impl<S, H, Tr: Trap<S>, F> Deref for Etable<S, H, Tr, F> {
 	type Target = [F; 256];
 
 	fn deref(&self) -> &[F; 256] {
@@ -27,21 +40,22 @@ impl<S, H, F> Deref for Etable<S, H, F> {
 	}
 }
 
-impl<S, H, F> DerefMut for Etable<S, H, F> {
+impl<S, H, Tr: Trap<S>, F> DerefMut for Etable<S, H, Tr, F> {
 	fn deref_mut(&mut self) -> &mut [F; 256] {
 		&mut self.0
 	}
 }
 
-impl<S, H, F> Etable<S, H, F>
+impl<S, H, Tr, F> Etable<S, H, Tr, F>
 where
-	F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control,
+	Tr: Trap<S>,
+	F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Tr::Data>,
 {
 	/// Wrap to create a new Etable.
-	pub fn wrap<FW, FR>(self, wrapper: FW) -> Etable<S, H, FR>
+	pub fn wrap<FW, FR>(self, wrapper: FW) -> Etable<S, H, Tr, FR>
 	where
 		FW: Fn(F, Opcode) -> FR,
-		FR: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control,
+		FR: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Tr::Data>,
 	{
 		let mut current_opcode = Opcode(0);
 		Etable(
@@ -57,9 +71,9 @@ where
 	}
 }
 
-impl<S, H> Etable<S, H> {
+impl<S, H, Tr: Trap<S>> Etable<S, H, Tr> {
 	/// Default core value for Etable.
-	pub const fn core() -> Etable<S, H> {
+	pub const fn core() -> Self {
 		let mut table = [eval_unknown as _; 256];
 
 		table[Opcode::STOP.as_usize()] = eval_stop as _;
@@ -179,9 +193,15 @@ impl<S, H> Etable<S, H> {
 	}
 }
 
-impl<H: Handler> Etable<RuntimeState, H> {
+impl<S, H: Handler, Tr> Etable<S, H, Tr>
+where
+	S: AsRef<RuntimeState>,
+	H: Handler,
+	Tr: Trap<S>,
+	Tr::Data: From<RuntimeTrapData>,
+{
 	/// Runtime Etable.
-	pub const fn runtime() -> Etable<RuntimeState, H> {
+	pub const fn runtime() -> Self {
 		let mut table = Self::core();
 
 		table.0[Opcode::SHA3.as_usize()] = eval_sha3 as _;
@@ -215,1283 +235,1264 @@ impl<H: Handler> Etable<RuntimeState, H> {
 		table.0[Opcode::CHAINID.as_usize()] = eval_chainid as _;
 		table.0[Opcode::BASEFEE.as_usize()] = eval_basefee as _;
 
-		table.0[Opcode::CREATE.as_usize()] = eval_trap as _;
-		table.0[Opcode::CREATE2.as_usize()] = eval_trap as _;
-		table.0[Opcode::CALL.as_usize()] = eval_trap as _;
-		table.0[Opcode::CALLCODE.as_usize()] = eval_trap as _;
-		table.0[Opcode::DELEGATECALL.as_usize()] = eval_trap as _;
-		table.0[Opcode::STATICCALL.as_usize()] = eval_trap as _;
+		// table.0[Opcode::CREATE.as_usize()] = eval_trap as _;
+		// table.0[Opcode::CREATE2.as_usize()] = eval_trap as _;
+		// table.0[Opcode::CALL.as_usize()] = eval_trap as _;
+		// table.0[Opcode::CALLCODE.as_usize()] = eval_trap as _;
+		// table.0[Opcode::DELEGATECALL.as_usize()] = eval_trap as _;
+		// table.0[Opcode::STATICCALL.as_usize()] = eval_trap as _;
 
 		table
 	}
 }
 
-/// Control state.
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub enum Control {
-	Continue,
-	ContinueN(usize),
-	Exit(ExitResult),
-	Jump(usize),
-	Trap(Trap),
-}
-
-fn eval_stop<S, H>(
+fn eval_stop<S, H, Td>(
 	_machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	Control::Exit(ExitSucceed::Stopped.into())
 }
 
-fn eval_add<S, H>(
+fn eval_add<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_tuple!(machine, overflowing_add)
 }
 
-fn eval_mul<S, H>(
+fn eval_mul<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_tuple!(machine, overflowing_mul)
 }
 
-fn eval_sub<S, H>(
+fn eval_sub<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_tuple!(machine, overflowing_sub)
 }
 
-fn eval_div<S, H>(
+fn eval_div<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::arithmetic::div)
 }
 
-fn eval_sdiv<S, H>(
+fn eval_sdiv<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::arithmetic::sdiv)
 }
 
-fn eval_mod<S, H>(
+fn eval_mod<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::arithmetic::rem)
 }
 
-fn eval_smod<S, H>(
+fn eval_smod<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::arithmetic::srem)
 }
 
-fn eval_addmod<S, H>(
+fn eval_addmod<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op3_u256_fn!(machine, self::arithmetic::addmod)
 }
 
-fn eval_mulmod<S, H>(
+fn eval_mulmod<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op3_u256_fn!(machine, self::arithmetic::mulmod)
 }
 
-fn eval_exp<S, H>(
+fn eval_exp<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::arithmetic::exp)
 }
 
-fn eval_signextend<S, H>(
+fn eval_signextend<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::arithmetic::signextend)
 }
 
-fn eval_lt<S, H>(
+fn eval_lt<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_bool_ref!(machine, lt)
 }
 
-fn eval_gt<S, H>(
+fn eval_gt<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_bool_ref!(machine, gt)
 }
 
-fn eval_slt<S, H>(
+fn eval_slt<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::bitwise::slt)
 }
 
-fn eval_sgt<S, H>(
+fn eval_sgt<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::bitwise::sgt)
 }
 
-fn eval_eq<S, H>(
+fn eval_eq<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_bool_ref!(machine, eq)
 }
 
-fn eval_iszero<S, H>(
+fn eval_iszero<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op1_u256_fn!(machine, self::bitwise::iszero)
 }
 
-fn eval_and<S, H>(
+fn eval_and<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256!(machine, bitand)
 }
 
-fn eval_or<S, H>(
+fn eval_or<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256!(machine, bitor)
 }
 
-fn eval_xor<S, H>(
+fn eval_xor<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256!(machine, bitxor)
 }
 
-fn eval_not<S, H>(
+fn eval_not<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op1_u256_fn!(machine, self::bitwise::not)
 }
 
-fn eval_byte<S, H>(
+fn eval_byte<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::bitwise::byte)
 }
 
-fn eval_shl<S, H>(
+fn eval_shl<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::bitwise::shl)
 }
 
-fn eval_shr<S, H>(
+fn eval_shr<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::bitwise::shr)
 }
 
-fn eval_sar<S, H>(
+fn eval_sar<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	op2_u256_fn!(machine, self::bitwise::sar)
 }
 
-fn eval_codesize<S, H>(
+fn eval_codesize<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::codesize(machine)
 }
 
-fn eval_codecopy<S, H>(
+fn eval_codecopy<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::codecopy(machine)
 }
 
-fn eval_calldataload<S, H>(
+fn eval_calldataload<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::calldataload(machine)
 }
 
-fn eval_calldatasize<S, H>(
+fn eval_calldatasize<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::calldatasize(machine)
 }
 
-fn eval_calldatacopy<S, H>(
+fn eval_calldatacopy<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::calldatacopy(machine)
 }
 
-fn eval_pop<S, H>(
+fn eval_pop<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::pop(machine)
 }
 
-fn eval_mload<S, H>(
+fn eval_mload<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::mload(machine)
 }
 
-fn eval_mstore<S, H>(
+fn eval_mstore<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::mstore(machine)
 }
 
-fn eval_mstore8<S, H>(
+fn eval_mstore8<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::mstore8(machine)
 }
 
-fn eval_jump<S, H>(
+fn eval_jump<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::jump(machine)
 }
 
-fn eval_jumpi<S, H>(
+fn eval_jumpi<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::jumpi(machine)
 }
 
-fn eval_pc<S, H>(
+fn eval_pc<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::pc(machine, position)
 }
 
-fn eval_msize<S, H>(
+fn eval_msize<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::msize(machine)
 }
 
-fn eval_jumpdest<S, H>(
+fn eval_jumpdest<S, H, Td>(
 	_machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	Control::Continue
 }
 
-fn eval_push0<S, H>(
+fn eval_push0<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 0, position)
 }
 
-fn eval_push1<S, H>(
+fn eval_push1<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 1, position)
 }
 
-fn eval_push2<S, H>(
+fn eval_push2<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 2, position)
 }
 
-fn eval_push3<S, H>(
+fn eval_push3<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 3, position)
 }
 
-fn eval_push4<S, H>(
+fn eval_push4<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 4, position)
 }
 
-fn eval_push5<S, H>(
+fn eval_push5<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 5, position)
 }
 
-fn eval_push6<S, H>(
+fn eval_push6<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 6, position)
 }
 
-fn eval_push7<S, H>(
+fn eval_push7<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 7, position)
 }
 
-fn eval_push8<S, H>(
+fn eval_push8<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 8, position)
 }
 
-fn eval_push9<S, H>(
+fn eval_push9<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 9, position)
 }
 
-fn eval_push10<S, H>(
+fn eval_push10<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 10, position)
 }
 
-fn eval_push11<S, H>(
+fn eval_push11<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 11, position)
 }
 
-fn eval_push12<S, H>(
+fn eval_push12<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 12, position)
 }
 
-fn eval_push13<S, H>(
+fn eval_push13<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 13, position)
 }
 
-fn eval_push14<S, H>(
+fn eval_push14<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 14, position)
 }
 
-fn eval_push15<S, H>(
+fn eval_push15<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 15, position)
 }
 
-fn eval_push16<S, H>(
+fn eval_push16<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 16, position)
 }
 
-fn eval_push17<S, H>(
+fn eval_push17<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 17, position)
 }
 
-fn eval_push18<S, H>(
+fn eval_push18<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 18, position)
 }
 
-fn eval_push19<S, H>(
+fn eval_push19<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 19, position)
 }
 
-fn eval_push20<S, H>(
+fn eval_push20<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 20, position)
 }
 
-fn eval_push21<S, H>(
+fn eval_push21<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 21, position)
 }
 
-fn eval_push22<S, H>(
+fn eval_push22<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 22, position)
 }
 
-fn eval_push23<S, H>(
+fn eval_push23<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 23, position)
 }
 
-fn eval_push24<S, H>(
+fn eval_push24<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 24, position)
 }
 
-fn eval_push25<S, H>(
+fn eval_push25<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 25, position)
 }
 
-fn eval_push26<S, H>(
+fn eval_push26<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 26, position)
 }
 
-fn eval_push27<S, H>(
+fn eval_push27<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 27, position)
 }
 
-fn eval_push28<S, H>(
+fn eval_push28<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 28, position)
 }
 
-fn eval_push29<S, H>(
+fn eval_push29<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 29, position)
 }
 
-fn eval_push30<S, H>(
+fn eval_push30<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 30, position)
 }
 
-fn eval_push31<S, H>(
+fn eval_push31<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 31, position)
 }
 
-fn eval_push32<S, H>(
+fn eval_push32<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::push(machine, 32, position)
 }
 
-fn eval_dup1<S, H>(
+fn eval_dup1<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 1)
 }
 
-fn eval_dup2<S, H>(
+fn eval_dup2<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 2)
 }
 
-fn eval_dup3<S, H>(
+fn eval_dup3<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 3)
 }
 
-fn eval_dup4<S, H>(
+fn eval_dup4<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 4)
 }
 
-fn eval_dup5<S, H>(
+fn eval_dup5<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 5)
 }
 
-fn eval_dup6<S, H>(
+fn eval_dup6<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 6)
 }
 
-fn eval_dup7<S, H>(
+fn eval_dup7<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 7)
 }
 
-fn eval_dup8<S, H>(
+fn eval_dup8<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 8)
 }
 
-fn eval_dup9<S, H>(
+fn eval_dup9<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 9)
 }
 
-fn eval_dup10<S, H>(
+fn eval_dup10<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 10)
 }
 
-fn eval_dup11<S, H>(
+fn eval_dup11<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 11)
 }
 
-fn eval_dup12<S, H>(
+fn eval_dup12<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 12)
 }
 
-fn eval_dup13<S, H>(
+fn eval_dup13<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 13)
 }
 
-fn eval_dup14<S, H>(
+fn eval_dup14<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 14)
 }
 
-fn eval_dup15<S, H>(
+fn eval_dup15<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 15)
 }
 
-fn eval_dup16<S, H>(
+fn eval_dup16<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::dup(machine, 16)
 }
 
-fn eval_swap1<S, H>(
+fn eval_swap1<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 1)
 }
 
-fn eval_swap2<S, H>(
+fn eval_swap2<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 2)
 }
 
-fn eval_swap3<S, H>(
+fn eval_swap3<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 3)
 }
 
-fn eval_swap4<S, H>(
+fn eval_swap4<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 4)
 }
 
-fn eval_swap5<S, H>(
+fn eval_swap5<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 5)
 }
 
-fn eval_swap6<S, H>(
+fn eval_swap6<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 6)
 }
 
-fn eval_swap7<S, H>(
+fn eval_swap7<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 7)
 }
 
-fn eval_swap8<S, H>(
+fn eval_swap8<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 8)
 }
 
-fn eval_swap9<S, H>(
+fn eval_swap9<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 9)
 }
 
-fn eval_swap10<S, H>(
+fn eval_swap10<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 10)
 }
 
-fn eval_swap11<S, H>(
+fn eval_swap11<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 11)
 }
 
-fn eval_swap12<S, H>(
+fn eval_swap12<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 12)
 }
 
-fn eval_swap13<S, H>(
+fn eval_swap13<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 13)
 }
 
-fn eval_swap14<S, H>(
+fn eval_swap14<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 14)
 }
 
-fn eval_swap15<S, H>(
+fn eval_swap15<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 15)
 }
 
-fn eval_swap16<S, H>(
+fn eval_swap16<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::swap(machine, 16)
 }
 
-fn eval_return<S, H>(
+fn eval_return<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::ret(machine)
 }
 
-fn eval_revert<S, H>(
+fn eval_revert<S, H, Td>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::misc::revert(machine)
 }
 
-fn eval_invalid<S, H>(
+fn eval_invalid<S, H, Td>(
 	_machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	Control::Exit(ExitException::DesignatedInvalid.into())
 }
 
-fn eval_unknown<S, H>(
+fn eval_unknown<S, H, Td>(
 	_machine: &mut Machine<S>,
 	_handle: &mut H,
 	opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	Control::Exit(ExitException::InvalidOpcode(opcode).into())
 }
 
-fn eval_sha3<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_sha3<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::sha3(machine)
 }
 
-fn eval_address<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_address<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::address(machine)
 }
 
-fn eval_balance<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_balance<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::balance(machine, handle)
 }
 
-fn eval_selfbalance<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_selfbalance<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::selfbalance(machine, handle)
 }
 
-fn eval_origin<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_origin<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::origin(machine, handle)
 }
 
-fn eval_caller<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_caller<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::caller(machine)
 }
 
-fn eval_callvalue<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_callvalue<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::callvalue(machine)
 }
 
-fn eval_gasprice<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_gasprice<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::gasprice(machine, handle)
 }
 
-fn eval_extcodesize<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_extcodesize<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::extcodesize(machine, handle)
 }
 
-fn eval_extcodehash<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_extcodehash<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::extcodehash(machine, handle)
 }
 
-fn eval_extcodecopy<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_extcodecopy<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::extcodecopy(machine, handle)
 }
 
-fn eval_returndatasize<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_returndatasize<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::returndatasize(machine)
 }
 
-fn eval_returndatacopy<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_returndatacopy<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::returndatacopy(machine)
 }
 
-fn eval_blockhash<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_blockhash<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::blockhash(machine, handle)
 }
 
-fn eval_coinbase<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_coinbase<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::coinbase(machine, handle)
 }
 
-fn eval_timestamp<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_timestamp<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::timestamp(machine, handle)
 }
 
-fn eval_number<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_number<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::number(machine, handle)
 }
 
-fn eval_difficulty<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_difficulty<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::prevrandao(machine, handle)
 }
 
-fn eval_gaslimit<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_gaslimit<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::gaslimit(machine, handle)
 }
 
-fn eval_sload<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_sload<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::sload(machine, handle)
 }
 
-fn eval_sstore<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_sstore<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::sstore(machine, handle)
 }
 
-fn eval_gas<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_gas<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::gas(machine, handle)
 }
 
-fn eval_log0<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_log0<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::log(machine, 0, handle)
 }
 
-fn eval_log1<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_log1<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::log(machine, 1, handle)
 }
 
-fn eval_log2<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_log2<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::log(machine, 2, handle)
 }
 
-fn eval_log3<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_log3<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::log(machine, 3, handle)
 }
 
-fn eval_log4<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_log4<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::log(machine, 4, handle)
 }
 
-fn eval_suicide<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_suicide<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::suicide(machine, handle)
 }
 
-fn eval_chainid<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_chainid<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::chainid(machine, handle)
 }
 
-fn eval_basefee<H: Handler>(
-	machine: &mut Machine<RuntimeState>,
+fn eval_basefee<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control {
+) -> Control<Td> {
 	self::system::basefee(machine, handle)
-}
-
-fn eval_trap<S, H>(
-	_machine: &mut Machine<S>,
-	_handle: &mut H,
-	opcode: Opcode,
-	_position: usize,
-) -> Control {
-	Control::Trap(opcode)
 }

--- a/interpreter/src/eval/system.rs
+++ b/interpreter/src/eval/system.rs
@@ -1,10 +1,14 @@
 use super::Control;
-use crate::{ExitException, ExitFatal, ExitSucceed, Handler, RuntimeMachine};
+use crate::{
+	ExitException, ExitFatal, ExitSucceed, Handler, Machine, RuntimeState, RuntimeTrapData,
+};
 use alloc::vec::Vec;
 use primitive_types::{H256, U256};
 use sha3::{Digest, Keccak256};
 
-pub fn sha3(machine: &mut RuntimeMachine) -> Control {
+pub fn sha3<S: AsRef<RuntimeState>, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+) -> Control<Td> {
 	pop_u256!(machine, from, len);
 
 	try_or_fail!(machine.memory.resize_offset(from, len));
@@ -23,20 +27,28 @@ pub fn sha3(machine: &mut RuntimeMachine) -> Control {
 	Control::Continue
 }
 
-pub fn chainid<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn chainid<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	push_u256!(machine, handler.chain_id());
 
 	Control::Continue
 }
 
-pub fn address(machine: &mut RuntimeMachine) -> Control {
-	let ret = H256::from(machine.state.context.address);
+pub fn address<S: AsRef<RuntimeState>, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+) -> Control<Td> {
+	let ret = H256::from(machine.state.as_ref().context.address);
 	push!(machine, ret);
 
 	Control::Continue
 }
 
-pub fn balance<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) -> Control {
+pub fn balance<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &mut H,
+) -> Control<Td> {
 	pop!(machine, address);
 	try_or_fail!(handler.mark_hot(address.into(), None));
 	push_u256!(machine, handler.balance(address.into()));
@@ -44,30 +56,44 @@ pub fn balance<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) -> Con
 	Control::Continue
 }
 
-pub fn selfbalance<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
-	push_u256!(machine, handler.balance(machine.state.context.address));
+pub fn selfbalance<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
+	push_u256!(
+		machine,
+		handler.balance(machine.state.as_ref().context.address)
+	);
 
 	Control::Continue
 }
 
-pub fn origin<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn origin<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	let ret = H256::from(handler.origin());
 	push!(machine, ret);
 
 	Control::Continue
 }
 
-pub fn caller(machine: &mut RuntimeMachine) -> Control {
-	let ret = H256::from(machine.state.context.caller);
+pub fn caller<S: AsRef<RuntimeState>, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+) -> Control<Td> {
+	let ret = H256::from(machine.state.as_ref().context.caller);
 	push!(machine, ret);
 
 	Control::Continue
 }
 
-pub fn callvalue(machine: &mut RuntimeMachine) -> Control {
+pub fn callvalue<S: AsRef<RuntimeState>, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+) -> Control<Td> {
 	let mut ret = H256::default();
 	machine
 		.state
+		.as_ref()
 		.context
 		.apparent_value
 		.to_big_endian(&mut ret[..]);
@@ -76,7 +102,10 @@ pub fn callvalue(machine: &mut RuntimeMachine) -> Control {
 	Control::Continue
 }
 
-pub fn gasprice<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn gasprice<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	let mut ret = H256::default();
 	handler.gas_price().to_big_endian(&mut ret[..]);
 	push!(machine, ret);
@@ -84,7 +113,10 @@ pub fn gasprice<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Contro
 	Control::Continue
 }
 
-pub fn basefee<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn basefee<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	let mut ret = H256::default();
 	handler.block_base_fee_per_gas().to_big_endian(&mut ret[..]);
 	push!(machine, ret);
@@ -92,7 +124,10 @@ pub fn basefee<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control
 	Control::Continue
 }
 
-pub fn extcodesize<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) -> Control {
+pub fn extcodesize<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &mut H,
+) -> Control<Td> {
 	pop!(machine, address);
 	try_or_fail!(handler.mark_hot(address.into(), None));
 	let code_size = handler.code_size(address.into());
@@ -101,7 +136,10 @@ pub fn extcodesize<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) ->
 	Control::Continue
 }
 
-pub fn extcodehash<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) -> Control {
+pub fn extcodehash<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &mut H,
+) -> Control<Td> {
 	pop!(machine, address);
 	try_or_fail!(handler.mark_hot(address.into(), None));
 	let code_hash = handler.code_hash(address.into());
@@ -110,7 +148,10 @@ pub fn extcodehash<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) ->
 	Control::Continue
 }
 
-pub fn extcodecopy<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) -> Control {
+pub fn extcodecopy<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &mut H,
+) -> Control<Td> {
 	pop!(machine, address);
 	pop_u256!(machine, memory_offset, code_offset, len);
 
@@ -129,62 +170,86 @@ pub fn extcodecopy<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) ->
 	Control::Continue
 }
 
-pub fn returndatasize(machine: &mut RuntimeMachine) -> Control {
-	let size = U256::from(machine.state.retbuf.len());
+pub fn returndatasize<S: AsRef<RuntimeState>, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+) -> Control<Td> {
+	let size = U256::from(machine.state.as_ref().retbuf.len());
 	push_u256!(machine, size);
 
 	Control::Continue
 }
 
-pub fn returndatacopy(machine: &mut RuntimeMachine) -> Control {
+pub fn returndatacopy<S: AsRef<RuntimeState>, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+) -> Control<Td> {
 	pop_u256!(machine, memory_offset, data_offset, len);
 
 	try_or_fail!(machine.memory.resize_offset(memory_offset, len));
 	if data_offset
 		.checked_add(len)
-		.map(|l| l > U256::from(machine.state.retbuf.len()))
+		.map(|l| l > U256::from(machine.state.as_ref().retbuf.len()))
 		.unwrap_or(true)
 	{
 		return Control::Exit(ExitException::OutOfOffset.into());
 	}
 
-	match machine
-		.memory
-		.copy_large(memory_offset, data_offset, len, &machine.state.retbuf)
-	{
+	match machine.memory.copy_large(
+		memory_offset,
+		data_offset,
+		len,
+		&machine.state.as_ref().retbuf,
+	) {
 		Ok(()) => Control::Continue,
 		Err(e) => Control::Exit(e.into()),
 	}
 }
 
-pub fn blockhash<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn blockhash<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	pop_u256!(machine, number);
 	push!(machine, handler.block_hash(number));
 
 	Control::Continue
 }
 
-pub fn coinbase<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn coinbase<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	push!(machine, handler.block_coinbase().into());
 	Control::Continue
 }
 
-pub fn timestamp<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn timestamp<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	push_u256!(machine, handler.block_timestamp());
 	Control::Continue
 }
 
-pub fn number<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn number<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	push_u256!(machine, handler.block_number());
 	Control::Continue
 }
 
-pub fn difficulty<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn difficulty<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	push_u256!(machine, handler.block_difficulty());
 	Control::Continue
 }
 
-pub fn prevrandao<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn prevrandao<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	if let Some(rand) = handler.block_randomness() {
 		push!(machine, rand);
 		Control::Continue
@@ -193,37 +258,53 @@ pub fn prevrandao<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Cont
 	}
 }
 
-pub fn gaslimit<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn gaslimit<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	push_u256!(machine, handler.block_gas_limit());
 	Control::Continue
 }
 
-pub fn sload<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) -> Control {
+pub fn sload<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &mut H,
+) -> Control<Td> {
 	pop!(machine, index);
-	try_or_fail!(handler.mark_hot(machine.state.context.address, Some(index)));
-	let value = handler.storage(machine.state.context.address, index);
+	try_or_fail!(handler.mark_hot(machine.state.as_ref().context.address, Some(index)));
+	let value = handler.storage(machine.state.as_ref().context.address, index);
 	push!(machine, value);
 
 	Control::Continue
 }
 
-pub fn sstore<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) -> Control {
+pub fn sstore<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &mut H,
+) -> Control<Td> {
 	pop!(machine, index, value);
-	try_or_fail!(handler.mark_hot(machine.state.context.address, Some(index)));
+	try_or_fail!(handler.mark_hot(machine.state.as_ref().context.address, Some(index)));
 
-	match handler.set_storage(machine.state.context.address, index, value) {
+	match handler.set_storage(machine.state.as_ref().context.address, index, value) {
 		Ok(()) => Control::Continue,
 		Err(e) => Control::Exit(e.into()),
 	}
 }
 
-pub fn gas<H: Handler>(machine: &mut RuntimeMachine, handler: &H) -> Control {
+pub fn gas<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Td> {
 	push_u256!(machine, handler.gas_left());
 
 	Control::Continue
 }
 
-pub fn log<H: Handler>(machine: &mut RuntimeMachine, n: u8, handler: &mut H) -> Control {
+pub fn log<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	n: u8,
+	handler: &mut H,
+) -> Control<Td> {
 	pop_u256!(machine, offset, len);
 
 	try_or_fail!(machine.memory.resize_offset(offset, len));
@@ -246,16 +327,19 @@ pub fn log<H: Handler>(machine: &mut RuntimeMachine, n: u8, handler: &mut H) -> 
 		}
 	}
 
-	match handler.log(machine.state.context.address, topics, data) {
+	match handler.log(machine.state.as_ref().context.address, topics, data) {
 		Ok(()) => Control::Continue,
 		Err(e) => Control::Exit(e.into()),
 	}
 }
 
-pub fn suicide<H: Handler>(machine: &mut RuntimeMachine, handler: &mut H) -> Control {
+pub fn suicide<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
+	machine: &mut Machine<S>,
+	handler: &mut H,
+) -> Control<Td> {
 	pop!(machine, target);
 
-	match handler.mark_delete(machine.state.context.address, target.into()) {
+	match handler.mark_delete(machine.state.as_ref().context.address, target.into()) {
 		Ok(()) => (),
 		Err(e) => return Control::Exit(e.into()),
 	}

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -15,18 +15,67 @@ mod stack;
 mod utils;
 mod valids;
 
-pub use crate::error::{
-	Capture, ExitError, ExitException, ExitFatal, ExitResult, ExitSucceed, Trap,
-};
-pub use crate::eval::{Control, Efn, Etable, RuntimeEtable};
+pub use crate::error::{ExitError, ExitException, ExitFatal, ExitResult, ExitSucceed};
+pub use crate::eval::{Control, Efn, Etable};
 pub use crate::memory::Memory;
 pub use crate::opcode::Opcode;
-pub use crate::runtime::{Context, Handler, RuntimeMachine, RuntimeState};
+pub use crate::runtime::{Context, Handler, RuntimeState, RuntimeTrap, RuntimeTrapData};
 pub use crate::stack::Stack;
 pub use crate::valids::Valids;
 
 use alloc::rc::Rc;
 use alloc::vec::Vec;
+use core::convert::Infallible;
+
+pub type StandardMachine = Machine<RuntimeState>;
+pub type StandardControl = Control<StandardTrapData>;
+pub type StandardEfn<H> = Efn<RuntimeState, H, StandardTrapData>;
+pub type StandardEtable<H> = Etable<RuntimeState, H, StandardTrap>;
+pub type StandardTrapData = Box<RuntimeTrapData>;
+pub type StandardTrap = RuntimeTrap<RuntimeState>;
+
+/// Trap which indicates that an `ExternalOpcode` has to be handled.
+pub trait Trap<S> {
+	type Data;
+
+	fn create(data: Self::Data, machine: Machine<S>) -> Self;
+}
+
+impl<S> Trap<S> for Infallible {
+	type Data = Infallible;
+
+	fn create(data: Infallible, _machine: Machine<S>) -> Self {
+		match data {}
+	}
+}
+
+/// Capture represents the result of execution.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Capture<E, T> {
+	/// The machine has exited. It cannot be executed again.
+	Exit(E),
+	/// The machine has trapped. It is waiting for external information, and can
+	/// be executed again.
+	Trap(T),
+}
+
+impl<E, T> Capture<E, T> {
+	pub fn exit(self) -> Option<E> {
+		if let Self::Exit(e) = self {
+			Some(e)
+		} else {
+			None
+		}
+	}
+
+	pub fn trap(self) -> Option<T> {
+		if let Self::Trap(t) = self {
+			Some(t)
+		} else {
+			None
+		}
+	}
+}
 
 /// Core execution layer for EVM.
 pub struct Machine<S> {
@@ -91,80 +140,88 @@ impl<S> Machine<S> {
 	}
 
 	/// Loop stepping the machine, until it stops.
-	pub fn run<H, F>(
-		&mut self,
+	pub fn run<H, Tr, F>(
+		mut self,
 		handle: &mut H,
-		etable: &Etable<S, H, F>,
-	) -> Capture<ExitResult, Trap>
+		etable: &Etable<S, H, Tr, F>,
+	) -> Capture<(Self, ExitResult), Tr>
 	where
-		F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control,
+		F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Tr::Data>,
+		Tr: Trap<S>,
 	{
 		loop {
 			match self.step(handle, etable) {
-				Ok(()) => (),
+				Ok(s) => {
+					self = s;
+				}
 				Err(res) => return res,
 			}
 		}
 	}
 
 	/// Step the machine N times.
-	pub fn stepn<H, F>(
-		&mut self,
+	pub fn stepn<H, Tr, F>(
+		mut self,
 		n: usize,
 		handle: &mut H,
-		etable: &Etable<S, H, F>,
-	) -> Result<(), Capture<ExitResult, Trap>>
+		etable: &Etable<S, H, Tr, F>,
+	) -> Result<Self, Capture<(Self, ExitResult), Tr>>
 	where
-		F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control,
+		F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Tr::Data>,
+		Tr: Trap<S>,
 	{
 		for _ in 0..n {
 			match self.step(handle, etable) {
-				Ok(()) => (),
+				Ok(s) => {
+					self = s;
+				}
 				Err(res) => return Err(res),
 			}
 		}
 
-		Ok(())
+		Ok(self)
 	}
 
 	#[inline]
 	/// Step the machine, executing one opcode. It then returns.
-	pub fn step<H, F>(
-		&mut self,
+	pub fn step<H, Tr, F>(
+		mut self,
 		handle: &mut H,
-		etable: &Etable<S, H, F>,
-	) -> Result<(), Capture<ExitResult, Trap>>
+		etable: &Etable<S, H, Tr, F>,
+	) -> Result<Self, Capture<(Self, ExitResult), Tr>>
 	where
-		F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control,
+		F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Tr::Data>,
+		Tr: Trap<S>,
 	{
 		let position = self.position;
 		if position >= self.code.len() {
-			return Err(Capture::Exit(ExitSucceed::Stopped.into()));
+			return Err(Capture::Exit((self, ExitSucceed::Stopped.into())));
 		}
 
 		let opcode = Opcode(self.code[position]);
-		let control = etable[opcode.as_usize()](self, handle, opcode, self.position);
+		let position = self.position;
+		let control = etable[opcode.as_usize()](&mut self, handle, opcode, position);
 
 		match control {
 			Control::Continue => {
 				self.position += 1;
-				Ok(())
+				Ok(self)
 			}
 			Control::ContinueN(p) => {
 				self.position = position + p;
-				Ok(())
+				Ok(self)
 			}
 			Control::Exit(e) => {
 				self.position = self.code.len();
-				Err(Capture::Exit(e))
+				Err(Capture::Exit((self, e)))
 			}
 			Control::Jump(p) => {
 				self.position = p;
-				Ok(())
+				Ok(self)
 			}
-			Control::Trap(opcode) => {
+			Control::Trap(data) => {
 				self.position = position + 1;
-				Err(Capture::Trap(opcode))
+				Err(Capture::Trap(Tr::create(data, self)))
 			}
 		}
 	}

--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -1,8 +1,79 @@
-use crate::ExitError;
+use crate::{ExitError, Machine, Trap};
 use primitive_types::{H160, H256, U256};
 
-/// Runtime machine.
-pub type RuntimeMachine = crate::Machine<RuntimeState>;
+pub enum RuntimeTrapData {
+	Call {
+		target: H160,
+		transfer: Transfer,
+		input: Vec<u8>,
+		gas: U256,
+		scheme: CallScheme,
+		context: Context,
+	},
+	Create {
+		scheme: CreateScheme,
+		value: U256,
+		code: Vec<u8>,
+	},
+}
+
+pub struct RuntimeTrap<S> {
+	data: Box<RuntimeTrapData>,
+	machine: Machine<S>,
+}
+
+impl<S: AsRef<RuntimeState>> Trap<S> for RuntimeTrap<S> {
+	type Data = Box<RuntimeTrapData>;
+
+	fn create(data: Box<RuntimeTrapData>, machine: Machine<S>) -> Self {
+		Self { data, machine }
+	}
+}
+
+/// Create scheme.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum CreateScheme {
+	/// Legacy create scheme of `CREATE`.
+	Legacy {
+		/// Caller of the create.
+		caller: H160,
+	},
+	/// Create scheme of `CREATE2`.
+	Create2 {
+		/// Caller of the create.
+		caller: H160,
+		/// Code hash.
+		code_hash: H256,
+		/// Salt.
+		salt: H256,
+	},
+	/// Create at a fixed location.
+	Fixed(H160),
+}
+
+/// Call scheme.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum CallScheme {
+	/// `CALL`
+	Call,
+	/// `CALLCODE`
+	CallCode,
+	/// `DELEGATECALL`
+	DelegateCall,
+	/// `STATICCALL`
+	StaticCall,
+}
+
+/// Transfer from source to target, with given value.
+#[derive(Clone, Debug)]
+pub struct Transfer {
+	/// Source address.
+	pub source: H160,
+	/// Target address.
+	pub target: H160,
+	/// Transfer value.
+	pub value: U256,
+}
 
 /// Runtime state.
 #[derive(Clone, Debug)]
@@ -11,6 +82,12 @@ pub struct RuntimeState {
 	pub context: Context,
 	/// Return data buffer.
 	pub retbuf: Vec<u8>,
+}
+
+impl AsRef<RuntimeState> for RuntimeState {
+	fn as_ref(&self) -> &RuntimeState {
+		&self
+	}
 }
 
 /// Context of the runtime.

--- a/interpreter/tests/performance.rs
+++ b/interpreter/tests/performance.rs
@@ -1,7 +1,8 @@
-use evm_interpreter::{Capture, Etable, ExitSucceed, Machine};
+use evm_interpreter::{Etable, ExitSucceed, Machine};
+use std::convert::Infallible;
 use std::rc::Rc;
 
-static ETABLE: Etable<(), ()> = Etable::core();
+static ETABLE: Etable<(), (), Infallible> = Etable::core();
 
 macro_rules! ret_test {
 	( $name:ident, $code:expr, $data:expr, $ret:expr ) => {
@@ -12,8 +13,12 @@ macro_rules! ret_test {
 
 			let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000, ());
 			assert_eq!(
-				vm.run(&mut (), &ETABLE),
-				Capture::Exit(Ok(ExitSucceed::Returned.into()))
+				{
+					let res;
+					(vm, res) = vm.run::<_, Infallible, _>(&mut (), &ETABLE).exit().unwrap();
+					res
+				},
+				Ok(ExitSucceed::Returned.into())
 			);
 			assert_eq!(vm.into_retbuf(), hex::decode($ret).unwrap());
 		}

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -1,4 +1,9 @@
-use evm_interpreter::{Capture, Control, Etable, ExitSucceed, Machine, Opcode};
+use evm_interpreter::{
+	Context, Control, Etable, ExitError, ExitSucceed, Handler, Machine, Opcode, RuntimeState,
+	RuntimeTrapData, StandardEtable, StandardMachine, StandardTrap, StandardTrapData, Trap,
+};
+use primitive_types::{H160, H256, U256};
+use std::convert::Infallible;
 use std::rc::Rc;
 
 const CODE1: &str = "60e060020a6000350480632839e92814601e57806361047ff414603457005b602a6004356024356047565b8060005260206000f35b603d6004356099565b8060005260206000f35b600082600014605457605e565b8160010190506093565b81600014606957607b565b60756001840360016047565b90506093565b609060018403608c85600186036047565b6047565b90505b92915050565b6000816000148060a95750816001145b60b05760b7565b81905060cf565b60c1600283036099565b60cb600184036099565b0190505b91905056";
@@ -10,7 +15,7 @@ fn etable_wrap() {
 	let code = hex::decode(&CODE1).unwrap();
 	let data = hex::decode(&DATA1).unwrap();
 
-	let wrapped_etable = Etable::core().wrap(|f, opcode_t| {
+	let wrapped_etable = Etable::<_, _, Infallible>::core().wrap(|f, opcode_t| {
 		move |machine, handle, opcode, position| {
 			assert_eq!(opcode_t, opcode);
 			println!("opcode: {:?}", opcode);
@@ -19,9 +24,122 @@ fn etable_wrap() {
 	});
 
 	let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000, ());
-	let result = vm.run(&mut (), &wrapped_etable);
-	assert_eq!(result, Capture::Exit(Ok(ExitSucceed::Returned.into())));
+	let result;
+	(vm, result) = vm.run(&mut (), &wrapped_etable).exit().unwrap();
+	assert_eq!(result, Ok(ExitSucceed::Returned.into()));
 	assert_eq!(vm.into_retbuf(), hex::decode(&RET1).unwrap());
+}
+
+pub enum Wrap2TestTrapData {
+	Runtime(StandardTrapData),
+	Interrupt(Opcode),
+}
+
+impl From<RuntimeTrapData> for Wrap2TestTrapData {
+	fn from(r: RuntimeTrapData) -> Self {
+		Self::Runtime(Box::new(r))
+	}
+}
+
+pub enum Wrap2TestTrap {
+	Runtime(StandardTrap),
+	Interrupt(Opcode, StandardMachine),
+}
+
+impl Trap<RuntimeState> for Wrap2TestTrap {
+	type Data = Wrap2TestTrapData;
+
+	fn create(data: Wrap2TestTrapData, machine: StandardMachine) -> Self {
+		match data {
+			Wrap2TestTrapData::Runtime(s) => {
+				Wrap2TestTrap::Runtime(StandardTrap::create(s, machine))
+			}
+			Wrap2TestTrapData::Interrupt(s) => Wrap2TestTrap::Interrupt(s, machine),
+		}
+	}
+}
+
+pub struct UnimplementedHandler;
+
+impl Handler for UnimplementedHandler {
+	fn balance(&self, _address: H160) -> U256 {
+		unimplemented!()
+	}
+	fn code_size(&self, _address: H160) -> U256 {
+		unimplemented!()
+	}
+	fn code_hash(&self, _address: H160) -> H256 {
+		unimplemented!()
+	}
+	fn code(&self, _address: H160) -> Vec<u8> {
+		unimplemented!()
+	}
+	fn storage(&self, _address: H160, _index: H256) -> H256 {
+		unimplemented!()
+	}
+	fn original_storage(&self, _address: H160, _index: H256) -> H256 {
+		unimplemented!()
+	}
+
+	fn gas_left(&self) -> U256 {
+		unimplemented!()
+	}
+	fn gas_price(&self) -> U256 {
+		unimplemented!()
+	}
+	fn origin(&self) -> H160 {
+		unimplemented!()
+	}
+	fn block_hash(&self, _number: U256) -> H256 {
+		unimplemented!()
+	}
+	fn block_number(&self) -> U256 {
+		unimplemented!()
+	}
+	fn block_coinbase(&self) -> H160 {
+		unimplemented!()
+	}
+	fn block_timestamp(&self) -> U256 {
+		unimplemented!()
+	}
+	fn block_difficulty(&self) -> U256 {
+		unimplemented!()
+	}
+	fn block_randomness(&self) -> Option<H256> {
+		unimplemented!()
+	}
+	fn block_gas_limit(&self) -> U256 {
+		unimplemented!()
+	}
+	fn block_base_fee_per_gas(&self) -> U256 {
+		unimplemented!()
+	}
+	fn chain_id(&self) -> U256 {
+		unimplemented!()
+	}
+
+	fn exists(&self, _address: H160) -> bool {
+		unimplemented!()
+	}
+	fn deleted(&self, _address: H160) -> bool {
+		unimplemented!()
+	}
+	fn is_cold(&self, _address: H160, _index: Option<H256>) -> bool {
+		unimplemented!()
+	}
+	fn mark_hot(&mut self, _address: H160, _index: Option<H256>) -> Result<(), ExitError> {
+		unimplemented!()
+	}
+
+	fn set_storage(&mut self, _address: H160, _index: H256, _value: H256) -> Result<(), ExitError> {
+		unimplemented!()
+	}
+	fn log(&mut self, _address: H160, _topics: Vec<H256>, _data: Vec<u8>) -> Result<(), ExitError> {
+		unimplemented!()
+	}
+	fn mark_delete(&mut self, _address: H160, _target: H160) -> Result<(), ExitError> {
+		unimplemented!()
+	}
 }
 
 #[test]
@@ -29,8 +147,17 @@ fn etable_wrap2() {
 	let code = hex::decode(&CODE1).unwrap();
 	let data = hex::decode(&DATA1).unwrap();
 
-	let wrapped_etable = Etable::core().wrap(
-		|f, opcode_t| -> Box<dyn Fn(&mut Machine<()>, &mut (), Opcode, usize) -> Control> {
+	let wrapped_etable = Etable::runtime().wrap(
+		|f,
+		 opcode_t|
+		 -> Box<
+			dyn Fn(
+				&mut StandardMachine,
+				&mut UnimplementedHandler,
+				Opcode,
+				usize,
+			) -> Control<Wrap2TestTrapData>,
+		> {
 			if opcode_t != Opcode(0x50) {
 				Box::new(move |machine, handle, opcode, position| {
 					assert_eq!(opcode_t, opcode);
@@ -40,13 +167,59 @@ fn etable_wrap2() {
 			} else {
 				Box::new(|_machine, _handle, opcode, _position| {
 					println!("disabled!");
-					Control::Trap(opcode)
+					Control::Trap(Wrap2TestTrapData::Interrupt(opcode))
 				})
 			}
 		},
 	);
 
-	let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000, ());
-	let result = vm.run(&mut (), &wrapped_etable);
-	assert_eq!(result, Capture::Trap(Opcode(0x50)));
+	let vm = Machine::new(
+		Rc::new(code),
+		Rc::new(data),
+		1024,
+		10000,
+		RuntimeState {
+			context: Context {
+				address: H160::default(),
+				caller: H160::default(),
+				apparent_value: U256::default(),
+			},
+			retbuf: Vec::new(),
+		},
+	);
+	let trap = vm
+		.run(&mut UnimplementedHandler, &wrapped_etable)
+		.trap()
+		.unwrap();
+	match trap {
+		Wrap2TestTrap::Interrupt(opcode, _) => assert_eq!(opcode, Opcode(0x50)),
+		_ => panic!("expected Wrap2TestTrap::Interrupt"),
+	}
+}
+
+#[test]
+fn etable_standard() {
+	let code = hex::decode(&CODE1).unwrap();
+	let data = hex::decode(&DATA1).unwrap();
+	let etable: StandardEtable<UnimplementedHandler> = Etable::runtime();
+
+	let mut vm = Machine::new(
+		Rc::new(code),
+		Rc::new(data),
+		1024,
+		10000,
+		RuntimeState {
+			context: Context {
+				address: H160::default(),
+				caller: H160::default(),
+				apparent_value: U256::default(),
+			},
+			retbuf: Vec::new(),
+		},
+	);
+
+	let res;
+	(vm, res) = vm.run(&mut UnimplementedHandler, &etable).exit().unwrap();
+	assert_eq!(res, Ok(ExitSucceed::Returned.into()));
+	assert_eq!(vm.into_retbuf(), hex::decode(&RET1).unwrap());
 }


### PR DESCRIPTION
This makes it simpler to create custom interrupts by making the `Trap` type generic. `step`/`run` now take full ownership of `self`, so that `self` can later be moved into the trap.

This makes it possible to implement a large portion of `CALL`/`CREATE` in `Machine` (rather than `Executor`).