### PR TITLE
Revert new trapping design #193 and #194

### DIFF
--- a/interpreter/src/error.rs
+++ b/interpreter/src/error.rs
@@ -1,6 +1,19 @@
 use crate::Opcode;
 use alloc::borrow::Cow;
 
+/// Trap which indicates that an `ExternalOpcode` has to be handled.
+pub type Trap = Opcode;
+
+/// Capture represents the result of execution.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Capture<E, T> {
+	/// The machine has exited. It cannot be executed again.
+	Exit(E),
+	/// The machine has trapped. It is waiting for external information, and can
+	/// be executed again.
+	Trap(T),
+}
+
 pub type ExitResult = Result<ExitSucceed, ExitError>;
 
 /// Exit reason.

--- a/interpreter/src/eval/misc.rs
+++ b/interpreter/src/eval/misc.rs
@@ -4,14 +4,14 @@ use core::cmp::min;
 use primitive_types::{H256, U256};
 
 #[inline]
-pub fn codesize<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn codesize<S>(state: &mut Machine<S>) -> Control {
 	let size = U256::from(state.code.len());
 	push_u256!(state, size);
 	Control::Continue
 }
 
 #[inline]
-pub fn codecopy<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn codecopy<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, memory_offset, code_offset, len);
 
 	try_or_fail!(state.memory.resize_offset(memory_offset, len));
@@ -25,7 +25,7 @@ pub fn codecopy<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn calldataload<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn calldataload<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, index);
 
 	let mut load = [0u8; 32];
@@ -46,14 +46,14 @@ pub fn calldataload<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn calldatasize<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn calldatasize<S>(state: &mut Machine<S>) -> Control {
 	let len = U256::from(state.data.len());
 	push_u256!(state, len);
 	Control::Continue
 }
 
 #[inline]
-pub fn calldatacopy<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn calldatacopy<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, memory_offset, data_offset, len);
 
 	try_or_fail!(state.memory.resize_offset(memory_offset, len));
@@ -71,13 +71,13 @@ pub fn calldatacopy<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn pop<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn pop<S>(state: &mut Machine<S>) -> Control {
 	pop!(state, _val);
 	Control::Continue
 }
 
 #[inline]
-pub fn mload<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn mload<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, index);
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
 	let index = as_usize_or_fail!(index);
@@ -87,7 +87,7 @@ pub fn mload<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn mstore<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn mstore<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, index);
 	pop!(state, value);
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
@@ -99,7 +99,7 @@ pub fn mstore<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn mstore8<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn mstore8<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, index, value);
 	try_or_fail!(state.memory.resize_offset(index, U256::one()));
 	let index = as_usize_or_fail!(index);
@@ -111,7 +111,7 @@ pub fn mstore8<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn jump<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn jump<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, dest);
 	let dest = as_usize_or_fail!(dest, ExitException::InvalidJump);
 
@@ -123,7 +123,7 @@ pub fn jump<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn jumpi<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn jumpi<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, dest);
 	pop!(state, value);
 
@@ -140,19 +140,19 @@ pub fn jumpi<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn pc<S, Td>(state: &mut Machine<S>, position: usize) -> Control<Td> {
+pub fn pc<S>(state: &mut Machine<S>, position: usize) -> Control {
 	push_u256!(state, U256::from(position));
 	Control::Continue
 }
 
 #[inline]
-pub fn msize<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn msize<S>(state: &mut Machine<S>) -> Control {
 	push_u256!(state, state.memory.effective_len());
 	Control::Continue
 }
 
 #[inline]
-pub fn push<S, Td>(state: &mut Machine<S>, n: usize, position: usize) -> Control<Td> {
+pub fn push<S>(state: &mut Machine<S>, n: usize, position: usize) -> Control {
 	let end = min(position + 1 + n, state.code.len());
 	let slice = &state.code[(position + 1)..end];
 	let mut val = [0u8; 32];
@@ -164,7 +164,7 @@ pub fn push<S, Td>(state: &mut Machine<S>, n: usize, position: usize) -> Control
 }
 
 #[inline]
-pub fn dup<S, Td>(state: &mut Machine<S>, n: usize) -> Control<Td> {
+pub fn dup<S>(state: &mut Machine<S>, n: usize) -> Control {
 	let value = match state.stack.peek(n - 1) {
 		Ok(value) => value,
 		Err(e) => return Control::Exit(e.into()),
@@ -174,7 +174,7 @@ pub fn dup<S, Td>(state: &mut Machine<S>, n: usize) -> Control<Td> {
 }
 
 #[inline]
-pub fn swap<S, Td>(state: &mut Machine<S>, n: usize) -> Control<Td> {
+pub fn swap<S>(state: &mut Machine<S>, n: usize) -> Control {
 	let val1 = match state.stack.peek(0) {
 		Ok(value) => value,
 		Err(e) => return Control::Exit(e.into()),
@@ -195,7 +195,7 @@ pub fn swap<S, Td>(state: &mut Machine<S>, n: usize) -> Control<Td> {
 }
 
 #[inline]
-pub fn ret<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn ret<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, start, len);
 	try_or_fail!(state.memory.resize_offset(start, len));
 	state.memory.resize_to_range(start..(start + len));
@@ -203,7 +203,7 @@ pub fn ret<S, Td>(state: &mut Machine<S>) -> Control<Td> {
 }
 
 #[inline]
-pub fn revert<S, Td>(state: &mut Machine<S>) -> Control<Td> {
+pub fn revert<S>(state: &mut Machine<S>) -> Control {
 	pop_u256!(state, start, len);
 	try_or_fail!(state.memory.resize_offset(start, len));
 	state.memory.resize_to_range(start..(start + len));

--- a/interpreter/src/eval/mod.rs
+++ b/interpreter/src/eval/mod.rs
@@ -5,34 +5,21 @@ mod bitwise;
 mod misc;
 mod system;
 
-use crate::{
-	ExitException, ExitResult, ExitSucceed, Handler, Machine, Opcode, RuntimeState,
-	RuntimeTrapData, Trap,
-};
+use crate::{ExitException, ExitResult, ExitSucceed, Handler, Machine, Opcode, RuntimeState, Trap};
 use core::marker::PhantomData;
 use core::ops::{BitAnd, BitOr, BitXor, Deref, DerefMut};
 use primitive_types::{H256, U256};
 
-/// Control state.
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub enum Control<Td> {
-	Continue,
-	ContinueN(usize),
-	Exit(ExitResult),
-	Jump(usize),
-	Trap(Td),
-}
-
 /// Evaluation function type.
-pub type Efn<S, H, Td> = fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Td>;
+pub type Efn<S, H> = fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control;
 
 /// The evaluation table for the EVM.
-pub struct Etable<S, H, Tr: Trap<S>, F = Efn<S, H, <Tr as Trap<S>>::Data>>(
-	[F; 256],
-	PhantomData<(S, H, Tr)>,
-);
+pub struct Etable<S, H, F = Efn<S, H>>([F; 256], PhantomData<(S, H)>);
 
-impl<S, H, Tr: Trap<S>, F> Deref for Etable<S, H, Tr, F> {
+/// Runtime table.
+pub type RuntimeEtable<H, F = Efn<RuntimeState, H>> = Etable<RuntimeState, H, F>;
+
+impl<S, H, F> Deref for Etable<S, H, F> {
 	type Target = [F; 256];
 
 	fn deref(&self) -> &[F; 256] {
@@ -40,22 +27,21 @@ impl<S, H, Tr: Trap<S>, F> Deref for Etable<S, H, Tr, F> {
 	}
 }
 
-impl<S, H, Tr: Trap<S>, F> DerefMut for Etable<S, H, Tr, F> {
+impl<S, H, F> DerefMut for Etable<S, H, F> {
 	fn deref_mut(&mut self) -> &mut [F; 256] {
 		&mut self.0
 	}
 }
 
-impl<S, H, Tr, F> Etable<S, H, Tr, F>
+impl<S, H, F> Etable<S, H, F>
 where
-	Tr: Trap<S>,
-	F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Tr::Data>,
+	F: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control,
 {
 	/// Wrap to create a new Etable.
-	pub fn wrap<FW, FR>(self, wrapper: FW) -> Etable<S, H, Tr, FR>
+	pub fn wrap<FW, FR>(self, wrapper: FW) -> Etable<S, H, FR>
 	where
 		FW: Fn(F, Opcode) -> FR,
-		FR: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control<Tr::Data>,
+		FR: Fn(&mut Machine<S>, &mut H, Opcode, usize) -> Control,
 	{
 		let mut current_opcode = Opcode(0);
 		Etable(
@@ -71,9 +57,9 @@ where
 	}
 }
 
-impl<S, H, Tr: Trap<S>> Etable<S, H, Tr> {
+impl<S, H> Etable<S, H> {
 	/// Default core value for Etable.
-	pub const fn core() -> Self {
+	pub const fn core() -> Etable<S, H> {
 		let mut table = [eval_unknown as _; 256];
 
 		table[Opcode::STOP.as_usize()] = eval_stop as _;
@@ -193,15 +179,9 @@ impl<S, H, Tr: Trap<S>> Etable<S, H, Tr> {
 	}
 }
 
-impl<S, H: Handler, Tr> Etable<S, H, Tr>
-where
-	S: AsRef<RuntimeState>,
-	H: Handler,
-	Tr: Trap<S>,
-	Tr::Data: From<RuntimeTrapData>,
-{
+impl<H: Handler> Etable<RuntimeState, H> {
 	/// Runtime Etable.
-	pub const fn runtime() -> Self {
+	pub const fn runtime() -> Etable<RuntimeState, H> {
 		let mut table = Self::core();
 
 		table.0[Opcode::SHA3.as_usize()] = eval_sha3 as _;
@@ -235,1264 +215,1283 @@ where
 		table.0[Opcode::CHAINID.as_usize()] = eval_chainid as _;
 		table.0[Opcode::BASEFEE.as_usize()] = eval_basefee as _;
 
-		// table.0[Opcode::CREATE.as_usize()] = eval_trap as _;
-		// table.0[Opcode::CREATE2.as_usize()] = eval_trap as _;
-		// table.0[Opcode::CALL.as_usize()] = eval_trap as _;
-		// table.0[Opcode::CALLCODE.as_usize()] = eval_trap as _;
-		// table.0[Opcode::DELEGATECALL.as_usize()] = eval_trap as _;
-		// table.0[Opcode::STATICCALL.as_usize()] = eval_trap as _;
+		table.0[Opcode::CREATE.as_usize()] = eval_trap as _;
+		table.0[Opcode::CREATE2.as_usize()] = eval_trap as _;
+		table.0[Opcode::CALL.as_usize()] = eval_trap as _;
+		table.0[Opcode::CALLCODE.as_usize()] = eval_trap as _;
+		table.0[Opcode::DELEGATECALL.as_usize()] = eval_trap as _;
+		table.0[Opcode::STATICCALL.as_usize()] = eval_trap as _;
 
 		table
 	}
 }
 
-fn eval_stop<S, H, Td>(
+/// Control state.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum Control {
+	Continue,
+	ContinueN(usize),
+	Exit(ExitResult),
+	Jump(usize),
+	Trap(Trap),
+}
+
+fn eval_stop<S, H>(
 	_machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	Control::Exit(ExitSucceed::Stopped.into())
 }
 
-fn eval_add<S, H, Td>(
+fn eval_add<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_tuple!(machine, overflowing_add)
 }
 
-fn eval_mul<S, H, Td>(
+fn eval_mul<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_tuple!(machine, overflowing_mul)
 }
 
-fn eval_sub<S, H, Td>(
+fn eval_sub<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_tuple!(machine, overflowing_sub)
 }
 
-fn eval_div<S, H, Td>(
+fn eval_div<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::arithmetic::div)
 }
 
-fn eval_sdiv<S, H, Td>(
+fn eval_sdiv<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::arithmetic::sdiv)
 }
 
-fn eval_mod<S, H, Td>(
+fn eval_mod<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::arithmetic::rem)
 }
 
-fn eval_smod<S, H, Td>(
+fn eval_smod<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::arithmetic::srem)
 }
 
-fn eval_addmod<S, H, Td>(
+fn eval_addmod<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op3_u256_fn!(machine, self::arithmetic::addmod)
 }
 
-fn eval_mulmod<S, H, Td>(
+fn eval_mulmod<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op3_u256_fn!(machine, self::arithmetic::mulmod)
 }
 
-fn eval_exp<S, H, Td>(
+fn eval_exp<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::arithmetic::exp)
 }
 
-fn eval_signextend<S, H, Td>(
+fn eval_signextend<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::arithmetic::signextend)
 }
 
-fn eval_lt<S, H, Td>(
+fn eval_lt<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_bool_ref!(machine, lt)
 }
 
-fn eval_gt<S, H, Td>(
+fn eval_gt<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_bool_ref!(machine, gt)
 }
 
-fn eval_slt<S, H, Td>(
+fn eval_slt<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::bitwise::slt)
 }
 
-fn eval_sgt<S, H, Td>(
+fn eval_sgt<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::bitwise::sgt)
 }
 
-fn eval_eq<S, H, Td>(
+fn eval_eq<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_bool_ref!(machine, eq)
 }
 
-fn eval_iszero<S, H, Td>(
+fn eval_iszero<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op1_u256_fn!(machine, self::bitwise::iszero)
 }
 
-fn eval_and<S, H, Td>(
+fn eval_and<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256!(machine, bitand)
 }
 
-fn eval_or<S, H, Td>(
+fn eval_or<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256!(machine, bitor)
 }
 
-fn eval_xor<S, H, Td>(
+fn eval_xor<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256!(machine, bitxor)
 }
 
-fn eval_not<S, H, Td>(
+fn eval_not<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op1_u256_fn!(machine, self::bitwise::not)
 }
 
-fn eval_byte<S, H, Td>(
+fn eval_byte<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::bitwise::byte)
 }
 
-fn eval_shl<S, H, Td>(
+fn eval_shl<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::bitwise::shl)
 }
 
-fn eval_shr<S, H, Td>(
+fn eval_shr<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::bitwise::shr)
 }
 
-fn eval_sar<S, H, Td>(
+fn eval_sar<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	op2_u256_fn!(machine, self::bitwise::sar)
 }
 
-fn eval_codesize<S, H, Td>(
+fn eval_codesize<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::codesize(machine)
 }
 
-fn eval_codecopy<S, H, Td>(
+fn eval_codecopy<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::codecopy(machine)
 }
 
-fn eval_calldataload<S, H, Td>(
+fn eval_calldataload<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::calldataload(machine)
 }
 
-fn eval_calldatasize<S, H, Td>(
+fn eval_calldatasize<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::calldatasize(machine)
 }
 
-fn eval_calldatacopy<S, H, Td>(
+fn eval_calldatacopy<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::calldatacopy(machine)
 }
 
-fn eval_pop<S, H, Td>(
+fn eval_pop<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::pop(machine)
 }
 
-fn eval_mload<S, H, Td>(
+fn eval_mload<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::mload(machine)
 }
 
-fn eval_mstore<S, H, Td>(
+fn eval_mstore<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::mstore(machine)
 }
 
-fn eval_mstore8<S, H, Td>(
+fn eval_mstore8<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::mstore8(machine)
 }
 
-fn eval_jump<S, H, Td>(
+fn eval_jump<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::jump(machine)
 }
 
-fn eval_jumpi<S, H, Td>(
+fn eval_jumpi<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::jumpi(machine)
 }
 
-fn eval_pc<S, H, Td>(
+fn eval_pc<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::pc(machine, position)
 }
 
-fn eval_msize<S, H, Td>(
+fn eval_msize<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::msize(machine)
 }
 
-fn eval_jumpdest<S, H, Td>(
+fn eval_jumpdest<S, H>(
 	_machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	Control::Continue
 }
 
-fn eval_push0<S, H, Td>(
+fn eval_push0<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 0, position)
 }
 
-fn eval_push1<S, H, Td>(
+fn eval_push1<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 1, position)
 }
 
-fn eval_push2<S, H, Td>(
+fn eval_push2<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 2, position)
 }
 
-fn eval_push3<S, H, Td>(
+fn eval_push3<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 3, position)
 }
 
-fn eval_push4<S, H, Td>(
+fn eval_push4<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 4, position)
 }
 
-fn eval_push5<S, H, Td>(
+fn eval_push5<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 5, position)
 }
 
-fn eval_push6<S, H, Td>(
+fn eval_push6<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 6, position)
 }
 
-fn eval_push7<S, H, Td>(
+fn eval_push7<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 7, position)
 }
 
-fn eval_push8<S, H, Td>(
+fn eval_push8<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 8, position)
 }
 
-fn eval_push9<S, H, Td>(
+fn eval_push9<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 9, position)
 }
 
-fn eval_push10<S, H, Td>(
+fn eval_push10<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 10, position)
 }
 
-fn eval_push11<S, H, Td>(
+fn eval_push11<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 11, position)
 }
 
-fn eval_push12<S, H, Td>(
+fn eval_push12<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 12, position)
 }
 
-fn eval_push13<S, H, Td>(
+fn eval_push13<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 13, position)
 }
 
-fn eval_push14<S, H, Td>(
+fn eval_push14<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 14, position)
 }
 
-fn eval_push15<S, H, Td>(
+fn eval_push15<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 15, position)
 }
 
-fn eval_push16<S, H, Td>(
+fn eval_push16<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 16, position)
 }
 
-fn eval_push17<S, H, Td>(
+fn eval_push17<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 17, position)
 }
 
-fn eval_push18<S, H, Td>(
+fn eval_push18<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 18, position)
 }
 
-fn eval_push19<S, H, Td>(
+fn eval_push19<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 19, position)
 }
 
-fn eval_push20<S, H, Td>(
+fn eval_push20<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 20, position)
 }
 
-fn eval_push21<S, H, Td>(
+fn eval_push21<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 21, position)
 }
 
-fn eval_push22<S, H, Td>(
+fn eval_push22<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 22, position)
 }
 
-fn eval_push23<S, H, Td>(
+fn eval_push23<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 23, position)
 }
 
-fn eval_push24<S, H, Td>(
+fn eval_push24<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 24, position)
 }
 
-fn eval_push25<S, H, Td>(
+fn eval_push25<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 25, position)
 }
 
-fn eval_push26<S, H, Td>(
+fn eval_push26<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 26, position)
 }
 
-fn eval_push27<S, H, Td>(
+fn eval_push27<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 27, position)
 }
 
-fn eval_push28<S, H, Td>(
+fn eval_push28<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 28, position)
 }
 
-fn eval_push29<S, H, Td>(
+fn eval_push29<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 29, position)
 }
 
-fn eval_push30<S, H, Td>(
+fn eval_push30<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 30, position)
 }
 
-fn eval_push31<S, H, Td>(
+fn eval_push31<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 31, position)
 }
 
-fn eval_push32<S, H, Td>(
+fn eval_push32<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::push(machine, 32, position)
 }
 
-fn eval_dup1<S, H, Td>(
+fn eval_dup1<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 1)
 }
 
-fn eval_dup2<S, H, Td>(
+fn eval_dup2<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 2)
 }
 
-fn eval_dup3<S, H, Td>(
+fn eval_dup3<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 3)
 }
 
-fn eval_dup4<S, H, Td>(
+fn eval_dup4<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 4)
 }
 
-fn eval_dup5<S, H, Td>(
+fn eval_dup5<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 5)
 }
 
-fn eval_dup6<S, H, Td>(
+fn eval_dup6<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 6)
 }
 
-fn eval_dup7<S, H, Td>(
+fn eval_dup7<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 7)
 }
 
-fn eval_dup8<S, H, Td>(
+fn eval_dup8<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 8)
 }
 
-fn eval_dup9<S, H, Td>(
+fn eval_dup9<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 9)
 }
 
-fn eval_dup10<S, H, Td>(
+fn eval_dup10<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 10)
 }
 
-fn eval_dup11<S, H, Td>(
+fn eval_dup11<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 11)
 }
 
-fn eval_dup12<S, H, Td>(
+fn eval_dup12<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 12)
 }
 
-fn eval_dup13<S, H, Td>(
+fn eval_dup13<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 13)
 }
 
-fn eval_dup14<S, H, Td>(
+fn eval_dup14<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 14)
 }
 
-fn eval_dup15<S, H, Td>(
+fn eval_dup15<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 15)
 }
 
-fn eval_dup16<S, H, Td>(
+fn eval_dup16<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::dup(machine, 16)
 }
 
-fn eval_swap1<S, H, Td>(
+fn eval_swap1<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 1)
 }
 
-fn eval_swap2<S, H, Td>(
+fn eval_swap2<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 2)
 }
 
-fn eval_swap3<S, H, Td>(
+fn eval_swap3<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 3)
 }
 
-fn eval_swap4<S, H, Td>(
+fn eval_swap4<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 4)
 }
 
-fn eval_swap5<S, H, Td>(
+fn eval_swap5<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 5)
 }
 
-fn eval_swap6<S, H, Td>(
+fn eval_swap6<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 6)
 }
 
-fn eval_swap7<S, H, Td>(
+fn eval_swap7<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 7)
 }
 
-fn eval_swap8<S, H, Td>(
+fn eval_swap8<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 8)
 }
 
-fn eval_swap9<S, H, Td>(
+fn eval_swap9<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 9)
 }
 
-fn eval_swap10<S, H, Td>(
+fn eval_swap10<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 10)
 }
 
-fn eval_swap11<S, H, Td>(
+fn eval_swap11<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 11)
 }
 
-fn eval_swap12<S, H, Td>(
+fn eval_swap12<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 12)
 }
 
-fn eval_swap13<S, H, Td>(
+fn eval_swap13<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 13)
 }
 
-fn eval_swap14<S, H, Td>(
+fn eval_swap14<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 14)
 }
 
-fn eval_swap15<S, H, Td>(
+fn eval_swap15<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 15)
 }
 
-fn eval_swap16<S, H, Td>(
+fn eval_swap16<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::swap(machine, 16)
 }
 
-fn eval_return<S, H, Td>(
+fn eval_return<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::ret(machine)
 }
 
-fn eval_revert<S, H, Td>(
+fn eval_revert<S, H>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::misc::revert(machine)
 }
 
-fn eval_invalid<S, H, Td>(
+fn eval_invalid<S, H>(
 	_machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	Control::Exit(ExitException::DesignatedInvalid.into())
 }
 
-fn eval_unknown<S, H, Td>(
+fn eval_unknown<S, H>(
 	_machine: &mut Machine<S>,
 	_handle: &mut H,
 	opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	Control::Exit(ExitException::InvalidOpcode(opcode).into())
 }
 
-fn eval_sha3<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_sha3<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::sha3(machine)
 }
 
-fn eval_address<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_address<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::address(machine)
 }
 
-fn eval_balance<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_balance<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::balance(machine, handle)
 }
 
-fn eval_selfbalance<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_selfbalance<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::selfbalance(machine, handle)
 }
 
-fn eval_origin<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_origin<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::origin(machine, handle)
 }
 
-fn eval_caller<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_caller<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::caller(machine)
 }
 
-fn eval_callvalue<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_callvalue<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::callvalue(machine)
 }
 
-fn eval_gasprice<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_gasprice<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::gasprice(machine, handle)
 }
 
-fn eval_extcodesize<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_extcodesize<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::extcodesize(machine, handle)
 }
 
-fn eval_extcodehash<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_extcodehash<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::extcodehash(machine, handle)
 }
 
-fn eval_extcodecopy<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_extcodecopy<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::extcodecopy(machine, handle)
 }
 
-fn eval_returndatasize<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_returndatasize<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::returndatasize(machine)
 }
 
-fn eval_returndatacopy<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_returndatacopy<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	_handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::returndatacopy(machine)
 }
 
-fn eval_blockhash<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_blockhash<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::blockhash(machine, handle)
 }
 
-fn eval_coinbase<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_coinbase<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::coinbase(machine, handle)
 }
 
-fn eval_timestamp<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_timestamp<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::timestamp(machine, handle)
 }
 
-fn eval_number<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_number<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::number(machine, handle)
 }
 
-fn eval_difficulty<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_difficulty<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::prevrandao(machine, handle)
 }
 
-fn eval_gaslimit<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_gaslimit<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::gaslimit(machine, handle)
 }
 
-fn eval_sload<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_sload<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::sload(machine, handle)
 }
 
-fn eval_sstore<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_sstore<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::sstore(machine, handle)
 }
 
-fn eval_gas<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_gas<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::gas(machine, handle)
 }
 
-fn eval_log0<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_log0<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::log(machine, 0, handle)
 }
 
-fn eval_log1<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_log1<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::log(machine, 1, handle)
 }
 
-fn eval_log2<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_log2<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::log(machine, 2, handle)
 }
 
-fn eval_log3<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_log3<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::log(machine, 3, handle)
 }
 
-fn eval_log4<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_log4<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::log(machine, 4, handle)
 }
 
-fn eval_suicide<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_suicide<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::suicide(machine, handle)
 }
 
-fn eval_chainid<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_chainid<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::chainid(machine, handle)
 }
 
-fn eval_basefee<S: AsRef<RuntimeState>, H: Handler, Td: From<RuntimeTrapData>>(
-	machine: &mut Machine<S>,
+fn eval_basefee<H: Handler>(
+	machine: &mut Machine<RuntimeState>,
 	handle: &mut H,
 	_opcode: Opcode,
 	_position: usize,
-) -> Control<Td> {
+) -> Control {
 	self::system::basefee(machine, handle)
+}
+
+fn eval_trap<S, H>(
+	_machine: &mut Machine<S>,
+	_handle: &mut H,
+	opcode: Opcode,
+	_position: usize,
+) -> Control {
+	Control::Trap(opcode)
 }

--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -1,79 +1,8 @@
-use crate::{ExitError, Machine, Trap};
+use crate::ExitError;
 use primitive_types::{H160, H256, U256};
 
-pub enum RuntimeTrapData {
-	Call {
-		target: H160,
-		transfer: Transfer,
-		input: Vec<u8>,
-		gas: U256,
-		scheme: CallScheme,
-		context: Context,
-	},
-	Create {
-		scheme: CreateScheme,
-		value: U256,
-		code: Vec<u8>,
-	},
-}
-
-pub struct RuntimeTrap<S> {
-	data: Box<RuntimeTrapData>,
-	machine: Machine<S>,
-}
-
-impl<S: AsRef<RuntimeState>> Trap<S> for RuntimeTrap<S> {
-	type Data = Box<RuntimeTrapData>;
-
-	fn create(data: Box<RuntimeTrapData>, machine: Machine<S>) -> Self {
-		Self { data, machine }
-	}
-}
-
-/// Create scheme.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
-pub enum CreateScheme {
-	/// Legacy create scheme of `CREATE`.
-	Legacy {
-		/// Caller of the create.
-		caller: H160,
-	},
-	/// Create scheme of `CREATE2`.
-	Create2 {
-		/// Caller of the create.
-		caller: H160,
-		/// Code hash.
-		code_hash: H256,
-		/// Salt.
-		salt: H256,
-	},
-	/// Create at a fixed location.
-	Fixed(H160),
-}
-
-/// Call scheme.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
-pub enum CallScheme {
-	/// `CALL`
-	Call,
-	/// `CALLCODE`
-	CallCode,
-	/// `DELEGATECALL`
-	DelegateCall,
-	/// `STATICCALL`
-	StaticCall,
-}
-
-/// Transfer from source to target, with given value.
-#[derive(Clone, Debug)]
-pub struct Transfer {
-	/// Source address.
-	pub source: H160,
-	/// Target address.
-	pub target: H160,
-	/// Transfer value.
-	pub value: U256,
-}
+/// Runtime machine.
+pub type RuntimeMachine = crate::Machine<RuntimeState>;
 
 /// Runtime state.
 #[derive(Clone, Debug)]
@@ -82,12 +11,6 @@ pub struct RuntimeState {
 	pub context: Context,
 	/// Return data buffer.
 	pub retbuf: Vec<u8>,
-}
-
-impl AsRef<RuntimeState> for RuntimeState {
-	fn as_ref(&self) -> &RuntimeState {
-		&self
-	}
 }
 
 /// Context of the runtime.

--- a/interpreter/tests/performance.rs
+++ b/interpreter/tests/performance.rs
@@ -1,8 +1,7 @@
-use evm_interpreter::{Etable, ExitSucceed, Machine};
-use std::convert::Infallible;
+use evm_interpreter::{Capture, Etable, ExitSucceed, Machine};
 use std::rc::Rc;
 
-static ETABLE: Etable<(), (), Infallible> = Etable::core();
+static ETABLE: Etable<(), ()> = Etable::core();
 
 macro_rules! ret_test {
 	( $name:ident, $code:expr, $data:expr, $ret:expr ) => {
@@ -13,12 +12,8 @@ macro_rules! ret_test {
 
 			let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000, ());
 			assert_eq!(
-				{
-					let res;
-					(vm, res) = vm.run::<_, Infallible, _>(&mut (), &ETABLE).exit().unwrap();
-					res
-				},
-				Ok(ExitSucceed::Returned.into())
+				vm.run(&mut (), &ETABLE),
+				Capture::Exit(Ok(ExitSucceed::Returned.into()))
 			);
 			assert_eq!(vm.into_retbuf(), hex::decode($ret).unwrap());
 		}

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -1,9 +1,4 @@
-use evm_interpreter::{
-	Context, Control, Etable, ExitError, ExitSucceed, Handler, Machine, Opcode, RuntimeState,
-	RuntimeTrapData, StandardEtable, StandardMachine, StandardTrap, StandardTrapData, Trap,
-};
-use primitive_types::{H160, H256, U256};
-use std::convert::Infallible;
+use evm_interpreter::{Capture, Control, Etable, ExitSucceed, Machine, Opcode};
 use std::rc::Rc;
 
 const CODE1: &str = "60e060020a6000350480632839e92814601e57806361047ff414603457005b602a6004356024356047565b8060005260206000f35b603d6004356099565b8060005260206000f35b600082600014605457605e565b8160010190506093565b81600014606957607b565b60756001840360016047565b90506093565b609060018403608c85600186036047565b6047565b90505b92915050565b6000816000148060a95750816001145b60b05760b7565b81905060cf565b60c1600283036099565b60cb600184036099565b0190505b91905056";
@@ -15,7 +10,7 @@ fn etable_wrap() {
 	let code = hex::decode(&CODE1).unwrap();
 	let data = hex::decode(&DATA1).unwrap();
 
-	let wrapped_etable = Etable::<_, _, Infallible>::core().wrap(|f, opcode_t| {
+	let wrapped_etable = Etable::core().wrap(|f, opcode_t| {
 		move |machine, handle, opcode, position| {
 			assert_eq!(opcode_t, opcode);
 			println!("opcode: {:?}", opcode);
@@ -24,122 +19,9 @@ fn etable_wrap() {
 	});
 
 	let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000, ());
-	let result;
-	(vm, result) = vm.run(&mut (), &wrapped_etable).exit().unwrap();
-	assert_eq!(result, Ok(ExitSucceed::Returned.into()));
+	let result = vm.run(&mut (), &wrapped_etable);
+	assert_eq!(result, Capture::Exit(Ok(ExitSucceed::Returned.into())));
 	assert_eq!(vm.into_retbuf(), hex::decode(&RET1).unwrap());
-}
-
-pub enum Wrap2TestTrapData {
-	Runtime(StandardTrapData),
-	Interrupt(Opcode),
-}
-
-impl From<RuntimeTrapData> for Wrap2TestTrapData {
-	fn from(r: RuntimeTrapData) -> Self {
-		Self::Runtime(Box::new(r))
-	}
-}
-
-pub enum Wrap2TestTrap {
-	Runtime(StandardTrap),
-	Interrupt(Opcode, StandardMachine),
-}
-
-impl Trap<RuntimeState> for Wrap2TestTrap {
-	type Data = Wrap2TestTrapData;
-
-	fn create(data: Wrap2TestTrapData, machine: StandardMachine) -> Self {
-		match data {
-			Wrap2TestTrapData::Runtime(s) => {
-				Wrap2TestTrap::Runtime(StandardTrap::create(s, machine))
-			}
-			Wrap2TestTrapData::Interrupt(s) => Wrap2TestTrap::Interrupt(s, machine),
-		}
-	}
-}
-
-pub struct UnimplementedHandler;
-
-impl Handler for UnimplementedHandler {
-	fn balance(&self, _address: H160) -> U256 {
-		unimplemented!()
-	}
-	fn code_size(&self, _address: H160) -> U256 {
-		unimplemented!()
-	}
-	fn code_hash(&self, _address: H160) -> H256 {
-		unimplemented!()
-	}
-	fn code(&self, _address: H160) -> Vec<u8> {
-		unimplemented!()
-	}
-	fn storage(&self, _address: H160, _index: H256) -> H256 {
-		unimplemented!()
-	}
-	fn original_storage(&self, _address: H160, _index: H256) -> H256 {
-		unimplemented!()
-	}
-
-	fn gas_left(&self) -> U256 {
-		unimplemented!()
-	}
-	fn gas_price(&self) -> U256 {
-		unimplemented!()
-	}
-	fn origin(&self) -> H160 {
-		unimplemented!()
-	}
-	fn block_hash(&self, _number: U256) -> H256 {
-		unimplemented!()
-	}
-	fn block_number(&self) -> U256 {
-		unimplemented!()
-	}
-	fn block_coinbase(&self) -> H160 {
-		unimplemented!()
-	}
-	fn block_timestamp(&self) -> U256 {
-		unimplemented!()
-	}
-	fn block_difficulty(&self) -> U256 {
-		unimplemented!()
-	}
-	fn block_randomness(&self) -> Option<H256> {
-		unimplemented!()
-	}
-	fn block_gas_limit(&self) -> U256 {
-		unimplemented!()
-	}
-	fn block_base_fee_per_gas(&self) -> U256 {
-		unimplemented!()
-	}
-	fn chain_id(&self) -> U256 {
-		unimplemented!()
-	}
-
-	fn exists(&self, _address: H160) -> bool {
-		unimplemented!()
-	}
-	fn deleted(&self, _address: H160) -> bool {
-		unimplemented!()
-	}
-	fn is_cold(&self, _address: H160, _index: Option<H256>) -> bool {
-		unimplemented!()
-	}
-	fn mark_hot(&mut self, _address: H160, _index: Option<H256>) -> Result<(), ExitError> {
-		unimplemented!()
-	}
-
-	fn set_storage(&mut self, _address: H160, _index: H256, _value: H256) -> Result<(), ExitError> {
-		unimplemented!()
-	}
-	fn log(&mut self, _address: H160, _topics: Vec<H256>, _data: Vec<u8>) -> Result<(), ExitError> {
-		unimplemented!()
-	}
-	fn mark_delete(&mut self, _address: H160, _target: H160) -> Result<(), ExitError> {
-		unimplemented!()
-	}
 }
 
 #[test]
@@ -147,17 +29,8 @@ fn etable_wrap2() {
 	let code = hex::decode(&CODE1).unwrap();
 	let data = hex::decode(&DATA1).unwrap();
 
-	let wrapped_etable = Etable::runtime().wrap(
-		|f,
-		 opcode_t|
-		 -> Box<
-			dyn Fn(
-				&mut StandardMachine,
-				&mut UnimplementedHandler,
-				Opcode,
-				usize,
-			) -> Control<Wrap2TestTrapData>,
-		> {
+	let wrapped_etable = Etable::core().wrap(
+		|f, opcode_t| -> Box<dyn Fn(&mut Machine<()>, &mut (), Opcode, usize) -> Control> {
 			if opcode_t != Opcode(0x50) {
 				Box::new(move |machine, handle, opcode, position| {
 					assert_eq!(opcode_t, opcode);
@@ -167,59 +40,13 @@ fn etable_wrap2() {
 			} else {
 				Box::new(|_machine, _handle, opcode, _position| {
 					println!("disabled!");
-					Control::Trap(Wrap2TestTrapData::Interrupt(opcode))
+					Control::Trap(opcode)
 				})
 			}
 		},
 	);
 
-	let vm = Machine::new(
-		Rc::new(code),
-		Rc::new(data),
-		1024,
-		10000,
-		RuntimeState {
-			context: Context {
-				address: H160::default(),
-				caller: H160::default(),
-				apparent_value: U256::default(),
-			},
-			retbuf: Vec::new(),
-		},
-	);
-	let trap = vm
-		.run(&mut UnimplementedHandler, &wrapped_etable)
-		.trap()
-		.unwrap();
-	match trap {
-		Wrap2TestTrap::Interrupt(opcode, _) => assert_eq!(opcode, Opcode(0x50)),
-		_ => panic!("expected Wrap2TestTrap::Interrupt"),
-	}
-}
-
-#[test]
-fn etable_standard() {
-	let code = hex::decode(&CODE1).unwrap();
-	let data = hex::decode(&DATA1).unwrap();
-	let etable: StandardEtable<UnimplementedHandler> = Etable::runtime();
-
-	let mut vm = Machine::new(
-		Rc::new(code),
-		Rc::new(data),
-		1024,
-		10000,
-		RuntimeState {
-			context: Context {
-				address: H160::default(),
-				caller: H160::default(),
-				apparent_value: U256::default(),
-			},
-			retbuf: Vec::new(),
-		},
-	);
-
-	let res;
-	(vm, res) = vm.run(&mut UnimplementedHandler, &etable).exit().unwrap();
-	assert_eq!(res, Ok(ExitSucceed::Returned.into()));
-	assert_eq!(vm.into_retbuf(), hex::decode(&RET1).unwrap());
+	let mut vm = Machine::new(Rc::new(code), Rc::new(data), 1024, 10000, ());
+	let result = vm.run(&mut (), &wrapped_etable);
+	assert_eq!(result, Capture::Trap(Opcode(0x50)));
 }


### PR DESCRIPTION
While the new interface is nice, it also adds a lot of complexity due to generics. From my practical usability tests, in most cases, one will have to create a lot of "filler structs" for it to be fully functional.

We therefore revert back to the previous non-generic trapping design -- everything can be implemented via this as well, just without the nicer "feedback" interface.