### PR TITLE
Tweak gasometer interface

### DIFF
--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -73,6 +73,19 @@ impl<S> Machine<S> {
 		}
 	}
 
+	pub fn perform<R, F: FnOnce(&mut Self) -> Result<R, ExitError>>(
+		&mut self,
+		f: F,
+	) -> Result<R, ExitError> {
+		match f(self) {
+			Ok(r) => Ok(r),
+			Err(e) => {
+				self.exit();
+				Err(e)
+			}
+		}
+	}
+
 	/// Explicit exit of the machine. Further step will return error.
 	pub fn exit(&mut self) {
 		self.position = self.code.len();

--- a/interpreter/src/stack.rs
+++ b/interpreter/src/stack.rs
@@ -42,6 +42,11 @@ impl Stack {
 		&self.data
 	}
 
+	/// Clear the stack.
+	pub fn clear(&mut self) {
+		self.data.clear()
+	}
+
 	#[inline]
 	/// Pop a value from the stack. If the stack is already empty, returns the
 	/// `StackUnderflow` error.


### PR DESCRIPTION
Take only the mutable reference instead of ownership. This turns out to massively simplify the interface in certain situations.