### PR TITLE
Improve stack checking

### DIFF
--- a/interpreter/src/eval/macros.rs
+++ b/interpreter/src/eval/macros.rs
@@ -1,5 +1,5 @@
 macro_rules! try_or_fail {
-	( $e:expr ) => {
+	($e:expr) => {
 		match $e {
 			Ok(v) => v,
 			Err(e) => return Control::Exit(e.into()),
@@ -54,7 +54,7 @@ macro_rules! push_u256 {
 }
 
 macro_rules! op1_u256_fn {
-	( $machine:expr, $op:path ) => {{
+	($machine:expr, $op:path) => {{
 		pop_u256!($machine, op1);
 		let ret = $op(op1);
 		push_u256!($machine, ret);
@@ -64,7 +64,7 @@ macro_rules! op1_u256_fn {
 }
 
 macro_rules! op2_u256_bool_ref {
-	( $machine:expr, $op:ident ) => {{
+	($machine:expr, $op:ident) => {{
 		pop_u256!($machine, op1, op2);
 		let ret = op1.$op(&op2);
 		push_u256!($machine, if ret { U256::one() } else { U256::zero() });
@@ -74,7 +74,7 @@ macro_rules! op2_u256_bool_ref {
 }
 
 macro_rules! op2_u256 {
-	( $machine:expr, $op:ident ) => {{
+	($machine:expr, $op:ident) => {{
 		pop_u256!($machine, op1, op2);
 		let ret = op1.$op(op2);
 		push_u256!($machine, ret);
@@ -84,7 +84,7 @@ macro_rules! op2_u256 {
 }
 
 macro_rules! op2_u256_tuple {
-	( $machine:expr, $op:ident ) => {{
+	($machine:expr, $op:ident) => {{
 		pop_u256!($machine, op1, op2);
 		let (ret, ..) = op1.$op(op2);
 		push_u256!($machine, ret);
@@ -94,7 +94,7 @@ macro_rules! op2_u256_tuple {
 }
 
 macro_rules! op2_u256_fn {
-	( $machine:expr, $op:path ) => {{
+	($machine:expr, $op:path) => {{
 		pop_u256!($machine, op1, op2);
 		let ret = $op(op1, op2);
 		push_u256!($machine, ret);
@@ -104,7 +104,7 @@ macro_rules! op2_u256_fn {
 }
 
 macro_rules! op3_u256_fn {
-	( $machine:expr, $op:path ) => {{
+	($machine:expr, $op:path) => {{
 		pop_u256!($machine, op1, op2, op3);
 		let ret = $op(op1, op2, op3);
 		push_u256!($machine, ret);
@@ -114,7 +114,7 @@ macro_rules! op3_u256_fn {
 }
 
 macro_rules! as_usize_or_fail {
-	( $v:expr ) => {{
+	($v:expr) => {{
 		if $v > U256::from(usize::MAX) {
 			return Control::Exit(ExitFatal::NotSupported.into());
 		}
@@ -122,7 +122,7 @@ macro_rules! as_usize_or_fail {
 		$v.as_usize()
 	}};
 
-	( $v:expr, $reason:expr ) => {{
+	($v:expr, $reason:expr) => {{
 		if $v > U256::from(usize::MAX) {
 			return Control::Exit($reason.into());
 		}

--- a/interpreter/src/eval/misc.rs
+++ b/interpreter/src/eval/misc.rs
@@ -1,13 +1,18 @@
 use super::Control;
+use crate::utils::u256_to_h256;
 use crate::{ExitError, ExitException, ExitFatal, ExitSucceed, Machine};
 use core::cmp::min;
 use primitive_types::{H256, U256};
 
 #[inline]
 pub fn codesize<S>(state: &mut Machine<S>) -> Control {
-	let size = U256::from(state.code.len());
-	push_u256!(state, size);
-	Control::Continue
+	let stack = &mut state.stack;
+	let code = &state.code;
+
+	stack.perform_pop0_push1(|| {
+		let size = U256::from(code.len());
+		Ok(u256_to_h256(size))
+	})
 }
 
 #[inline]

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -12,7 +12,7 @@ mod memory;
 mod opcode;
 mod runtime;
 mod stack;
-mod utils;
+pub mod utils;
 mod valids;
 
 pub use crate::error::{

--- a/interpreter/src/stack.rs
+++ b/interpreter/src/stack.rs
@@ -1,4 +1,4 @@
-use crate::ExitException;
+use crate::{Control, ExitError, ExitException, ExitResult};
 use alloc::vec::Vec;
 use primitive_types::H256;
 
@@ -7,6 +7,68 @@ use primitive_types::H256;
 pub struct Stack {
 	data: Vec<H256>,
 	limit: usize,
+}
+
+macro_rules! impl_perform_popn_pushn {
+    (
+        $name:ident,
+        $pop_len:expr,
+        $push_len:expr,
+        ($($peek_pop:expr),*),
+        ($($peek_push:expr),*),
+        $pop_pushn_f:ident
+    ) => {
+        #[allow(unused_parens)]
+        pub fn $name<F>(&mut self, f: F) -> Control where
+            F: FnOnce($(impl_perform_popn_pushn!(INTERNAL_TYPE_RH256, $peek_pop)),*) -> Result<($(impl_perform_popn_pushn!(INTERNAL_TYPE_H256, $peek_push)),*), ExitError>
+        {
+            match self.check_pop_push($pop_len, $push_len) {
+                Ok(()) => (),
+                Err(e) => return Control::Exit(Err(e.into())),
+            }
+
+            let p = match f($(self.peek_nocheck($peek_pop)),*) {
+                Ok(p1) => p1,
+                Err(e) => return Control::Exit(Err(e.into())),
+            };
+            self.$pop_pushn_f($pop_len, p);
+
+            Control::Continue
+        }
+    };
+    (INTERNAL_TYPE_RH256, $e:expr) => { &H256 };
+    (INTERNAL_TYPE_H256, $e:expr) => { H256 };
+}
+
+macro_rules! impl_perform_popn_pushn_exit {
+    (
+        $name:ident,
+        $pop_len:expr,
+        $push_len:expr,
+        ($($peek_pop:expr),*),
+        ($($peek_push:expr),*),
+        $pop_pushn_f:ident
+    ) => {
+        #[allow(unused_parens)]
+        pub fn $name<F>(&mut self, f: F) -> Control where
+            F: FnOnce($(impl_perform_popn_pushn_exit!(INTERNAL_TYPE_RH256, $peek_pop)),*) -> Result<(($(impl_perform_popn_pushn_exit!(INTERNAL_TYPE_H256, $peek_push)),*), ExitResult), ExitError>
+        {
+            match self.check_pop_push($pop_len, $push_len) {
+                Ok(()) => (),
+                Err(e) => return Control::Exit(Err(e.into())),
+            }
+
+            let (p, ret) = match f($(self.peek_nocheck($peek_pop)),*) {
+                Ok(p1) => p1,
+                Err(e) => return Control::Exit(Err(e.into())),
+            };
+            self.$pop_pushn_f($pop_len, p);
+
+            Control::Exit(ret)
+        }
+    };
+    (INTERNAL_TYPE_RH256, $e:expr) => { &H256 };
+    (INTERNAL_TYPE_H256, $e:expr) => { H256 };
 }
 
 impl Stack {
@@ -65,6 +127,33 @@ impl Stack {
 		Ok(())
 	}
 
+	pub fn check_pop_push(&self, pop: usize, push: usize) -> Result<(), ExitException> {
+		if self.data.len() >= pop {
+			return Err(ExitException::StackUnderflow);
+		}
+		if self.data.len() - pop + push <= self.limit {
+			return Err(ExitException::StackOverflow);
+		}
+		Ok(())
+	}
+
+	fn peek_nocheck(&self, no_from_top: usize) -> &H256 {
+		&self.data[self.data.len() - no_from_top - 1]
+	}
+
+	fn pop_push1_nocheck(&mut self, pop: usize, p1: H256) {
+		for _ in 0..pop {
+			self.data.pop();
+		}
+		self.data.push(p1);
+	}
+
+	fn pop_push0_nocheck(&mut self, pop: usize, _p1: ()) {
+		for _ in 0..pop {
+			self.data.pop();
+		}
+	}
+
 	#[inline]
 	/// Peek a value at given index for the stack, where the top of
 	/// the stack is at index `0`. If the index is too large,
@@ -90,4 +179,11 @@ impl Stack {
 			Err(ExitException::StackUnderflow)
 		}
 	}
+
+	impl_perform_popn_pushn!(perform_pop0_push1, 0, 1, (), (0), pop_push1_nocheck);
+	impl_perform_popn_pushn!(perform_pop1_push0, 1, 0, (0), (), pop_push0_nocheck);
+	impl_perform_popn_pushn!(perform_pop1_push1, 1, 1, (0), (0), pop_push1_nocheck);
+	impl_perform_popn_pushn!(perform_pop2_push1, 2, 1, (0, 1), (0), pop_push1_nocheck);
+
+	impl_perform_popn_pushn_exit!(perform_pop1_push0_exit, 1, 0, (0), (), pop_push0_nocheck);
 }

--- a/interpreter/src/utils.rs
+++ b/interpreter/src/utils.rs
@@ -1,6 +1,12 @@
 use core::cmp::Ordering;
 use core::ops::{Div, Rem};
-use primitive_types::U256;
+use primitive_types::{H256, U256};
+
+pub fn u256_to_h256(v: U256) -> H256 {
+	let mut r = H256::default();
+	v.to_big_endian(&mut r[..]);
+	r
+}
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Sign {

--- a/interpreter/tests/performance.rs
+++ b/interpreter/tests/performance.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 static ETABLE: Etable<(), ()> = Etable::core();
 
 macro_rules! ret_test {
-	( $name:ident, $code:expr, $data:expr, $ret:expr ) => {
+	($name:ident, $code:expr, $data:expr, $ret:expr) => {
 		#[test]
 		fn $name() {
 			let code = hex::decode($code).unwrap();


### PR DESCRIPTION
This adds a better framework for stack pop/push checking. This ensures that an EVM `step` is repeatable -- if it returns errors, then the state of the stack is exactly as pre-execution.

This doesn't matter much for production, but helps in certain situations for debugging. And branch removal will make it a bit faster.