### PR TITLE
New implementation for callcreate trap

### DIFF
--- a/interpreter/src/call_create.rs
+++ b/interpreter/src/call_create.rs
@@ -1,0 +1,376 @@
+use crate::utils::{h256_to_u256, u256_to_usize};
+use crate::{Context, ExitError, ExitException, ExitResult, Machine, Memory, RuntimeState};
+use core::cmp::{max, min};
+use primitive_types::{H160, H256, U256};
+use sha3::{Digest, Keccak256};
+
+/// Create scheme.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum CreateScheme {
+	/// Legacy create scheme of `CREATE`.
+	Legacy {
+		/// Caller of the create.
+		caller: H160,
+	},
+	/// Create scheme of `CREATE2`.
+	Create2 {
+		/// Caller of the create.
+		caller: H160,
+		/// Code hash.
+		code_hash: H256,
+		/// Salt.
+		salt: H256,
+	},
+	/// Create at a fixed location.
+	Fixed(H160),
+}
+
+/// Call scheme.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum CallScheme {
+	/// `CALL`
+	Call,
+	/// `CALLCODE`
+	CallCode,
+	/// `DELEGATECALL`
+	DelegateCall,
+	/// `STATICCALL`
+	StaticCall,
+}
+
+/// Transfer from source to target, with given value.
+#[derive(Clone, Debug)]
+pub struct Transfer {
+	/// Source address.
+	pub source: H160,
+	/// Target address.
+	pub target: H160,
+	/// Transfer value.
+	pub value: U256,
+}
+
+pub struct CallTrapData {
+	pub target: H160,
+	pub transfer: Option<Transfer>,
+	pub input: Vec<u8>,
+	pub gas: U256,
+	pub is_static: bool,
+	pub out_offset: U256,
+	pub out_len: U256,
+	pub context: Context,
+}
+
+impl CallTrapData {
+	fn new_from_params<S: AsRef<RuntimeState> + AsMut<RuntimeState>>(
+		scheme: CallScheme,
+		memory: &mut Memory,
+		state: &mut S,
+		gas: &H256,
+		to: &H256,
+		value: Option<&H256>,
+		in_offset: &H256,
+		in_len: &H256,
+		out_offset: &H256,
+		out_len: &H256,
+	) -> Result<((), Self), ExitError> {
+		let gas = h256_to_u256(*gas);
+		let value = value.map(|v| h256_to_u256(*v)).unwrap_or(U256::zero());
+		let in_offset = h256_to_u256(*in_offset);
+		let in_len = h256_to_u256(*in_len);
+		let out_offset = h256_to_u256(*out_offset);
+		let out_len = h256_to_u256(*out_len);
+
+		let in_end = in_offset
+			.checked_add(in_len)
+			.ok_or(ExitException::InvalidRange)?;
+		let out_end = out_offset
+			.checked_add(out_len)
+			.ok_or(ExitException::InvalidRange)?;
+
+		let in_offset_len = if in_len == U256::zero() {
+			None
+		} else {
+			Some((u256_to_usize(in_offset)?, u256_to_usize(in_len)?))
+		};
+
+		memory.resize_end(max(in_end, out_end))?;
+
+		let input = in_offset_len
+			.map(|(in_offset, in_len)| memory.get(in_offset, in_len))
+			.unwrap_or(Vec::new());
+
+		let context = match scheme {
+			CallScheme::Call | CallScheme::StaticCall => Context {
+				address: (*to).into(),
+				caller: state.as_ref().context.address,
+				apparent_value: value,
+			},
+			CallScheme::CallCode => Context {
+				address: state.as_ref().context.address,
+				caller: state.as_ref().context.address,
+				apparent_value: value,
+			},
+			CallScheme::DelegateCall => Context {
+				address: state.as_ref().context.address,
+				caller: state.as_ref().context.caller,
+				apparent_value: state.as_ref().context.apparent_value,
+			},
+		};
+
+		let transfer = if scheme == CallScheme::Call {
+			Some(Transfer {
+				source: state.as_ref().context.address,
+				target: (*to).into(),
+				value,
+			})
+		} else if scheme == CallScheme::CallCode {
+			Some(Transfer {
+				source: state.as_ref().context.address,
+				target: state.as_ref().context.address,
+				value,
+			})
+		} else {
+			None
+		};
+
+		state.as_mut().retbuf = Vec::new();
+
+		Ok((
+			(),
+			Self {
+				target: (*to).into(),
+				transfer,
+				input,
+				gas,
+				is_static: scheme == CallScheme::StaticCall,
+				context,
+				out_offset,
+				out_len,
+			},
+		))
+	}
+
+	pub fn new_from<S: AsRef<RuntimeState> + AsMut<RuntimeState>>(
+		scheme: CallScheme,
+		machine: &mut Machine<S>,
+	) -> Result<Self, ExitError> {
+		let stack = &mut machine.stack;
+		let memory = &mut machine.memory;
+		let state = &mut machine.state;
+
+		match scheme {
+			CallScheme::Call | CallScheme::CallCode => stack.perform_pop7_push0(
+				|gas, to, value, in_offset, in_len, out_offset, out_len| {
+					Self::new_from_params(
+						scheme,
+						memory,
+						state,
+						gas,
+						to,
+						Some(value),
+						in_offset,
+						in_len,
+						out_offset,
+						out_len,
+					)
+				},
+			),
+			CallScheme::DelegateCall | CallScheme::StaticCall => {
+				stack.perform_pop6_push0(|gas, to, in_offset, in_len, out_offset, out_len| {
+					Self::new_from_params(
+						scheme, memory, state, gas, to, None, in_offset, in_len, out_offset,
+						out_len,
+					)
+				})
+			}
+		}
+	}
+
+	pub fn feedback<S: AsRef<RuntimeState> + AsMut<RuntimeState>>(
+		self,
+		reason: ExitResult,
+		retbuf: Vec<u8>,
+		machine: &mut Machine<S>,
+	) -> Result<(), ExitError> {
+		let target_len = min(self.out_len, U256::from(retbuf.len()));
+		let out_offset = self.out_offset;
+
+		let ret = machine.perform(|machine| match reason {
+			Ok(_) => {
+				match machine
+					.memory
+					.copy_large(out_offset, U256::zero(), target_len, &retbuf[..])
+				{
+					Ok(()) => {
+						let mut value = H256::default();
+						U256::one().to_big_endian(&mut value[..]);
+						machine.stack.push(value)?;
+
+						Ok(())
+					}
+					Err(_) => {
+						machine.stack.push(H256::default())?;
+
+						Ok(())
+					}
+				}
+			}
+			Err(ExitError::Reverted) => {
+				machine.stack.push(H256::default())?;
+
+				let _ =
+					machine
+						.memory
+						.copy_large(out_offset, U256::zero(), target_len, &retbuf[..]);
+
+				Ok(())
+			}
+			Err(ExitError::Exception(_)) => {
+				machine.stack.push(H256::default())?;
+
+				Ok(())
+			}
+			Err(ExitError::Fatal(e)) => {
+				machine.stack.push(H256::default())?;
+
+				Err(e.into())
+			}
+		});
+
+		match ret {
+			Ok(()) => {
+				machine.state.as_mut().retbuf = retbuf;
+
+				machine.advance();
+				Ok(())
+			}
+			Err(e) => Err(e),
+		}
+	}
+}
+
+pub struct CreateTrapData {
+	pub scheme: CreateScheme,
+	pub value: U256,
+	pub code: Vec<u8>,
+}
+
+impl CreateTrapData {
+	pub fn new_create_from<S: AsRef<RuntimeState> + AsMut<RuntimeState>>(
+		machine: &mut Machine<S>,
+	) -> Result<Self, ExitError> {
+		let stack = &mut machine.stack;
+		let memory = &mut machine.memory;
+		let state = &mut machine.state;
+
+		stack.perform_pop3_push0(|value, code_offset, code_len| {
+			let value = h256_to_u256(*value);
+			let code_offset = h256_to_u256(*code_offset);
+			let code_len = h256_to_u256(*code_len);
+
+			let code_offset_len = if code_len == U256::zero() {
+				None
+			} else {
+				Some((u256_to_usize(code_offset)?, u256_to_usize(code_len)?))
+			};
+
+			let code = code_offset_len
+				.map(|(code_offset, code_len)| memory.get(code_offset, code_len))
+				.unwrap_or(Vec::new());
+
+			let scheme = CreateScheme::Legacy {
+				caller: state.as_ref().context.address,
+			};
+
+			state.as_mut().retbuf = Vec::new();
+
+			Ok((
+				(),
+				Self {
+					scheme,
+					value,
+					code,
+				},
+			))
+		})
+	}
+
+	pub fn new_create2_from<S: AsRef<RuntimeState> + AsMut<RuntimeState>>(
+		machine: &mut Machine<S>,
+	) -> Result<Self, ExitError> {
+		let stack = &mut machine.stack;
+		let memory = &mut machine.memory;
+		let state = &mut machine.state;
+
+		stack.perform_pop4_push0(|value, code_offset, code_len, salt| {
+			let value = h256_to_u256(*value);
+			let code_offset = h256_to_u256(*code_offset);
+			let code_len = h256_to_u256(*code_len);
+
+			let code_offset_len = if code_len == U256::zero() {
+				None
+			} else {
+				Some((u256_to_usize(code_offset)?, u256_to_usize(code_len)?))
+			};
+
+			let code = code_offset_len
+				.map(|(code_offset, code_len)| memory.get(code_offset, code_len))
+				.unwrap_or(Vec::new());
+
+			let code_hash = H256::from_slice(Keccak256::digest(&code).as_slice());
+
+			let scheme = CreateScheme::Create2 {
+				caller: state.as_ref().context.address,
+				salt: *salt,
+				code_hash,
+			};
+
+			state.as_mut().retbuf = Vec::new();
+
+			Ok((
+				(),
+				Self {
+					scheme,
+					value,
+					code,
+				},
+			))
+		})
+	}
+
+	pub fn feedback<S: AsRef<RuntimeState> + AsMut<RuntimeState>>(
+		self,
+		reason: Result<H160, ExitError>,
+		retbuf: Vec<u8>,
+		machine: &mut Machine<S>,
+	) -> Result<(), ExitError> {
+		let ret = machine.perform(|machine| match reason {
+			Ok(address) => {
+				machine.stack.push(address.into())?;
+				Ok(())
+			}
+			Err(ExitError::Reverted) => {
+				machine.stack.push(H256::default())?;
+				Ok(())
+			}
+			Err(ExitError::Exception(_)) => {
+				machine.stack.push(H256::default())?;
+				Ok(())
+			}
+			Err(ExitError::Fatal(e)) => {
+				machine.stack.push(H256::default())?;
+				Err(e.into())
+			}
+		});
+
+		match ret {
+			Ok(()) => {
+				machine.state.as_mut().retbuf = retbuf;
+
+				machine.advance();
+				Ok(())
+			}
+			Err(e) => Err(e),
+		}
+	}
+}

--- a/interpreter/src/error.rs
+++ b/interpreter/src/error.rs
@@ -1,9 +1,6 @@
 use crate::Opcode;
 use alloc::borrow::Cow;
 
-/// Trap which indicates that an `ExternalOpcode` has to be handled.
-pub type Trap = Opcode;
-
 /// Capture represents the result of execution.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Capture<E, T> {

--- a/interpreter/src/eval/system.rs
+++ b/interpreter/src/eval/system.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use primitive_types::{H256, U256};
 use sha3::{Digest, Keccak256};
 
-pub fn sha3<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Control {
+pub fn sha3<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<Tr> {
 	pop_u256!(machine, from, len);
 
 	try_or_fail!(machine.memory.resize_offset(from, len));
@@ -23,26 +23,26 @@ pub fn sha3<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Control {
 	Control::Continue
 }
 
-pub fn chainid<S: AsRef<RuntimeState>, H: Handler>(
+pub fn chainid<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	push_u256!(machine, handler.chain_id());
 
 	Control::Continue
 }
 
-pub fn address<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Control {
+pub fn address<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<Tr> {
 	let ret = H256::from(machine.state.as_ref().context.address);
 	push!(machine, ret);
 
 	Control::Continue
 }
 
-pub fn balance<S: AsRef<RuntimeState>, H: Handler>(
+pub fn balance<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
-) -> Control {
+) -> Control<Tr> {
 	pop!(machine, address);
 	try_or_fail!(handler.mark_hot(address.into(), None));
 	push_u256!(machine, handler.balance(address.into()));
@@ -50,10 +50,10 @@ pub fn balance<S: AsRef<RuntimeState>, H: Handler>(
 	Control::Continue
 }
 
-pub fn selfbalance<S: AsRef<RuntimeState>, H: Handler>(
+pub fn selfbalance<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	push_u256!(
 		machine,
 		handler.balance(machine.state.as_ref().context.address)
@@ -62,24 +62,24 @@ pub fn selfbalance<S: AsRef<RuntimeState>, H: Handler>(
 	Control::Continue
 }
 
-pub fn origin<S: AsRef<RuntimeState>, H: Handler>(
+pub fn origin<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	let ret = H256::from(handler.origin());
 	push!(machine, ret);
 
 	Control::Continue
 }
 
-pub fn caller<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Control {
+pub fn caller<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<Tr> {
 	let ret = H256::from(machine.state.as_ref().context.caller);
 	push!(machine, ret);
 
 	Control::Continue
 }
 
-pub fn callvalue<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Control {
+pub fn callvalue<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<Tr> {
 	let mut ret = H256::default();
 	machine
 		.state
@@ -92,10 +92,10 @@ pub fn callvalue<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Control {
 	Control::Continue
 }
 
-pub fn gasprice<S: AsRef<RuntimeState>, H: Handler>(
+pub fn gasprice<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	let mut ret = H256::default();
 	handler.gas_price().to_big_endian(&mut ret[..]);
 	push!(machine, ret);
@@ -103,10 +103,10 @@ pub fn gasprice<S: AsRef<RuntimeState>, H: Handler>(
 	Control::Continue
 }
 
-pub fn basefee<S: AsRef<RuntimeState>, H: Handler>(
+pub fn basefee<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	let mut ret = H256::default();
 	handler.block_base_fee_per_gas().to_big_endian(&mut ret[..]);
 	push!(machine, ret);
@@ -114,10 +114,10 @@ pub fn basefee<S: AsRef<RuntimeState>, H: Handler>(
 	Control::Continue
 }
 
-pub fn extcodesize<S: AsRef<RuntimeState>, H: Handler>(
+pub fn extcodesize<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
-) -> Control {
+) -> Control<Tr> {
 	pop!(machine, address);
 	try_or_fail!(handler.mark_hot(address.into(), None));
 	let code_size = handler.code_size(address.into());
@@ -126,10 +126,10 @@ pub fn extcodesize<S: AsRef<RuntimeState>, H: Handler>(
 	Control::Continue
 }
 
-pub fn extcodehash<S: AsRef<RuntimeState>, H: Handler>(
+pub fn extcodehash<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
-) -> Control {
+) -> Control<Tr> {
 	pop!(machine, address);
 	try_or_fail!(handler.mark_hot(address.into(), None));
 	let code_hash = handler.code_hash(address.into());
@@ -138,10 +138,10 @@ pub fn extcodehash<S: AsRef<RuntimeState>, H: Handler>(
 	Control::Continue
 }
 
-pub fn extcodecopy<S: AsRef<RuntimeState>, H: Handler>(
+pub fn extcodecopy<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
-) -> Control {
+) -> Control<Tr> {
 	pop!(machine, address);
 	pop_u256!(machine, memory_offset, code_offset, len);
 
@@ -160,14 +160,14 @@ pub fn extcodecopy<S: AsRef<RuntimeState>, H: Handler>(
 	Control::Continue
 }
 
-pub fn returndatasize<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Control {
+pub fn returndatasize<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<Tr> {
 	let size = U256::from(machine.state.as_ref().retbuf.len());
 	push_u256!(machine, size);
 
 	Control::Continue
 }
 
-pub fn returndatacopy<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Control {
+pub fn returndatacopy<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<Tr> {
 	pop_u256!(machine, memory_offset, data_offset, len);
 
 	try_or_fail!(machine.memory.resize_offset(memory_offset, len));
@@ -190,52 +190,52 @@ pub fn returndatacopy<S: AsRef<RuntimeState>>(machine: &mut Machine<S>) -> Contr
 	}
 }
 
-pub fn blockhash<S: AsRef<RuntimeState>, H: Handler>(
+pub fn blockhash<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	pop_u256!(machine, number);
 	push!(machine, handler.block_hash(number));
 
 	Control::Continue
 }
 
-pub fn coinbase<S: AsRef<RuntimeState>, H: Handler>(
+pub fn coinbase<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	push!(machine, handler.block_coinbase().into());
 	Control::Continue
 }
 
-pub fn timestamp<S: AsRef<RuntimeState>, H: Handler>(
+pub fn timestamp<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	push_u256!(machine, handler.block_timestamp());
 	Control::Continue
 }
 
-pub fn number<S: AsRef<RuntimeState>, H: Handler>(
+pub fn number<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	push_u256!(machine, handler.block_number());
 	Control::Continue
 }
 
-pub fn difficulty<S: AsRef<RuntimeState>, H: Handler>(
+pub fn difficulty<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	push_u256!(machine, handler.block_difficulty());
 	Control::Continue
 }
 
-pub fn prevrandao<S: AsRef<RuntimeState>, H: Handler>(
+pub fn prevrandao<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	if let Some(rand) = handler.block_randomness() {
 		push!(machine, rand);
 		Control::Continue
@@ -244,18 +244,18 @@ pub fn prevrandao<S: AsRef<RuntimeState>, H: Handler>(
 	}
 }
 
-pub fn gaslimit<S: AsRef<RuntimeState>, H: Handler>(
+pub fn gaslimit<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
-) -> Control {
+) -> Control<Tr> {
 	push_u256!(machine, handler.block_gas_limit());
 	Control::Continue
 }
 
-pub fn sload<S: AsRef<RuntimeState>, H: Handler>(
+pub fn sload<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
-) -> Control {
+) -> Control<Tr> {
 	pop!(machine, index);
 	try_or_fail!(handler.mark_hot(machine.state.as_ref().context.address, Some(index)));
 	let value = handler.storage(machine.state.as_ref().context.address, index);
@@ -264,10 +264,10 @@ pub fn sload<S: AsRef<RuntimeState>, H: Handler>(
 	Control::Continue
 }
 
-pub fn sstore<S: AsRef<RuntimeState>, H: Handler>(
+pub fn sstore<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
-) -> Control {
+) -> Control<Tr> {
 	pop!(machine, index, value);
 	try_or_fail!(handler.mark_hot(machine.state.as_ref().context.address, Some(index)));
 
@@ -277,17 +277,20 @@ pub fn sstore<S: AsRef<RuntimeState>, H: Handler>(
 	}
 }
 
-pub fn gas<S: AsRef<RuntimeState>, H: Handler>(machine: &mut Machine<S>, handler: &H) -> Control {
+pub fn gas<S: AsRef<RuntimeState>, H: Handler, Tr>(
+	machine: &mut Machine<S>,
+	handler: &H,
+) -> Control<Tr> {
 	push_u256!(machine, handler.gas_left());
 
 	Control::Continue
 }
 
-pub fn log<S: AsRef<RuntimeState>, H: Handler>(
+pub fn log<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	n: u8,
 	handler: &mut H,
-) -> Control {
+) -> Control<Tr> {
 	pop_u256!(machine, offset, len);
 
 	try_or_fail!(machine.memory.resize_offset(offset, len));
@@ -316,10 +319,10 @@ pub fn log<S: AsRef<RuntimeState>, H: Handler>(
 	}
 }
 
-pub fn suicide<S: AsRef<RuntimeState>, H: Handler>(
+pub fn suicide<S: AsRef<RuntimeState>, H: Handler, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
-) -> Control {
+) -> Control<Tr> {
 	pop!(machine, target);
 
 	match handler.mark_delete(machine.state.as_ref().context.address, target.into()) {

--- a/interpreter/src/memory.rs
+++ b/interpreter/src/memory.rs
@@ -115,7 +115,12 @@ impl Memory {
 
 		#[allow(clippy::needless_range_loop)]
 		for index in 0..size {
-			let position = offset + index;
+			let position = if let Some(position) = offset.checked_add(index) {
+				position
+			} else {
+				break;
+			};
+
 			if position >= self.data.len() {
 				break;
 			}

--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::ExitError;
+use crate::{ExitError, Opcode};
 use primitive_types::{H160, H256, U256};
 
 /// Runtime machine.
@@ -22,6 +22,16 @@ pub struct Context {
 	pub caller: H160,
 	/// Apparent value of the EVM.
 	pub apparent_value: U256,
+}
+
+pub trait CallCreateTrap: Sized {
+	fn call_create_trap(opcode: Opcode) -> Self;
+}
+
+impl CallCreateTrap for Opcode {
+	fn call_create_trap(opcode: Opcode) -> Self {
+		opcode
+	}
 }
 
 /// EVM context handler.

--- a/interpreter/src/stack.rs
+++ b/interpreter/src/stack.rs
@@ -1,4 +1,4 @@
-use crate::{Control, ExitError, ExitException, ExitResult};
+use crate::{ExitError, ExitException};
 use alloc::vec::Vec;
 use primitive_types::H256;
 
@@ -19,56 +19,23 @@ macro_rules! impl_perform_popn_pushn {
 		$pop_pushn_f:ident
 	) => {
 		#[allow(unused_parens)]
-		pub fn $name<F>(&mut self, f: F) -> Control where
+		pub fn $name<R, F>(&mut self, f: F) -> Result<R, ExitError> where
 			F: FnOnce(
 				$(impl_perform_popn_pushn!(INTERNAL_TYPE_RH256, $peek_pop)),*
-			) -> Result<($(impl_perform_popn_pushn!(INTERNAL_TYPE_H256, $peek_push)),*), ExitError>
+			) -> Result<(($(impl_perform_popn_pushn!(INTERNAL_TYPE_H256, $peek_push)),*), R), ExitError>
 		{
 			match self.check_pop_push($pop_len, $push_len) {
 				Ok(()) => (),
-				Err(e) => return Control::Exit(Err(e.into())),
+				Err(e) => return Err(e.into()),
 			}
 
-			let p = match f($(self.peek_nocheck($peek_pop)),*) {
+			let (p, ret) = match f($(self.unchecked_peek($peek_pop)),*) {
 				Ok(p1) => p1,
-				Err(e) => return Control::Exit(Err(e.into())),
+				Err(e) => return Err(e.into()),
 			};
 			self.$pop_pushn_f($pop_len, p);
 
-			Control::Continue
-		}
-	};
-	(INTERNAL_TYPE_RH256, $e:expr) => { &H256 };
-	(INTERNAL_TYPE_H256, $e:expr) => { H256 };
-}
-
-macro_rules! impl_perform_popn_pushn_exit {
-	(
-		$name:ident,
-		$pop_len:expr,
-		$push_len:expr,
-		($($peek_pop:expr),*),
-		($($peek_push:expr),*),
-		$pop_pushn_f:ident
-	) => {
-		#[allow(unused_parens)]
-		pub fn $name<F>(&mut self, f: F) -> Control where
-			F: FnOnce(
-				$(impl_perform_popn_pushn_exit!(INTERNAL_TYPE_RH256, $peek_pop)),*
-			) -> Result<(($(impl_perform_popn_pushn_exit!(INTERNAL_TYPE_H256, $peek_push)),*), ExitResult), ExitError>
-		{
-			match self.check_pop_push($pop_len, $push_len) {
-				Ok(()) => (),
-				Err(e) => return Control::Exit(Err(e.into())),
-			}
-
-			let (p, ret) = match f($(self.peek_nocheck($peek_pop)),*) {
-				Ok(p1) => p1,
-				Err(e) => return Control::Exit(Err(e.into())),
-			};
-			self.$pop_pushn_f($pop_len, p);
-
-			Control::Exit(ret)
+			Ok(ret)
 		}
 	};
 	(INTERNAL_TYPE_RH256, $e:expr) => { &H256 };
@@ -141,18 +108,18 @@ impl Stack {
 		Ok(())
 	}
 
-	fn peek_nocheck(&self, no_from_top: usize) -> &H256 {
+	fn unchecked_peek(&self, no_from_top: usize) -> &H256 {
 		&self.data[self.data.len() - no_from_top - 1]
 	}
 
-	fn pop_push1_nocheck(&mut self, pop: usize, p1: H256) {
+	fn unchecked_pop_push1(&mut self, pop: usize, p1: H256) {
 		for _ in 0..pop {
 			self.data.pop();
 		}
 		self.data.push(p1);
 	}
 
-	fn pop_push0_nocheck(&mut self, pop: usize, _p1: ()) {
+	fn unchecked_pop_push0(&mut self, pop: usize, _p1: ()) {
 		for _ in 0..pop {
 			self.data.pop();
 		}
@@ -184,10 +151,33 @@ impl Stack {
 		}
 	}
 
-	impl_perform_popn_pushn!(perform_pop0_push1, 0, 1, (), (0), pop_push1_nocheck);
-	impl_perform_popn_pushn!(perform_pop1_push0, 1, 0, (0), (), pop_push0_nocheck);
-	impl_perform_popn_pushn!(perform_pop1_push1, 1, 1, (0), (0), pop_push1_nocheck);
-	impl_perform_popn_pushn!(perform_pop2_push1, 2, 1, (0, 1), (0), pop_push1_nocheck);
-
-	impl_perform_popn_pushn_exit!(perform_pop1_push0_exit, 1, 0, (0), (), pop_push0_nocheck);
+	impl_perform_popn_pushn!(perform_pop0_push1, 0, 1, (), (0), unchecked_pop_push1);
+	impl_perform_popn_pushn!(perform_pop1_push0, 1, 0, (0), (), unchecked_pop_push0);
+	impl_perform_popn_pushn!(perform_pop1_push1, 1, 1, (0), (0), unchecked_pop_push1);
+	impl_perform_popn_pushn!(perform_pop2_push1, 2, 1, (0, 1), (0), unchecked_pop_push1);
+	impl_perform_popn_pushn!(perform_pop3_push0, 3, 0, (0, 1, 2), (), unchecked_pop_push0);
+	impl_perform_popn_pushn!(
+		perform_pop4_push0,
+		4,
+		0,
+		(0, 1, 2, 3),
+		(),
+		unchecked_pop_push0
+	);
+	impl_perform_popn_pushn!(
+		perform_pop6_push0,
+		6,
+		0,
+		(0, 1, 2, 3, 4, 5),
+		(),
+		unchecked_pop_push0
+	);
+	impl_perform_popn_pushn!(
+		perform_pop7_push0,
+		7,
+		0,
+		(0, 1, 2, 3, 4, 5, 6),
+		(),
+		unchecked_pop_push0
+	);
 }

--- a/interpreter/src/utils.rs
+++ b/interpreter/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::{ExitError, ExitFatal};
 use core::cmp::Ordering;
 use core::ops::{Div, Rem};
 use primitive_types::{H256, U256};
@@ -6,6 +7,17 @@ pub fn u256_to_h256(v: U256) -> H256 {
 	let mut r = H256::default();
 	v.to_big_endian(&mut r[..]);
 	r
+}
+
+pub fn h256_to_u256(v: H256) -> U256 {
+	U256::from_big_endian(&v[..])
+}
+
+pub fn u256_to_usize(v: U256) -> Result<usize, ExitError> {
+	if v > U256::from(usize::MAX) {
+		return Err(ExitFatal::NotSupported.into());
+	}
+	Ok(v.as_usize())
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/interpreter/tests/performance.rs
+++ b/interpreter/tests/performance.rs
@@ -1,7 +1,7 @@
 use evm_interpreter::{Capture, Etable, ExitSucceed, Machine};
 use std::rc::Rc;
 
-static ETABLE: Etable<(), ()> = Etable::core();
+static ETABLE: Etable<(), (), ()> = Etable::core();
 
 macro_rules! ret_test {
 	($name:ident, $code:expr, $data:expr, $ret:expr) => {

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -10,7 +10,7 @@ fn etable_wrap() {
 	let code = hex::decode(&CODE1).unwrap();
 	let data = hex::decode(&DATA1).unwrap();
 
-	let wrapped_etable = Etable::core().wrap(|f, opcode_t| {
+	let wrapped_etable = Etable::<_, _, Opcode>::core().wrap(|f, opcode_t| {
 		move |machine, handle, opcode, position| {
 			assert_eq!(opcode_t, opcode);
 			println!("opcode: {:?}", opcode);
@@ -30,7 +30,7 @@ fn etable_wrap2() {
 	let data = hex::decode(&DATA1).unwrap();
 
 	let wrapped_etable = Etable::core().wrap(
-		|f, opcode_t| -> Box<dyn Fn(&mut Machine<()>, &mut (), Opcode, usize) -> Control> {
+		|f, opcode_t| -> Box<dyn Fn(&mut Machine<()>, &mut (), Opcode, usize) -> Control<Opcode>> {
 			if opcode_t != Opcode(0x50) {
 				Box::new(move |machine, handle, opcode, position| {
 					assert_eq!(opcode_t, opcode);


### PR DESCRIPTION
* After some thoughts, I've decided to add back another generic version of `Trap`. This time, we don't do complicated trap wrapper any more and only deal with trap data. The trap data this time, is expected to be simple pointers, with the majority of things handled outside of `Machine`. This is ultimately also needed, because executors will need to distinguish callcreate traps vs other interrupt traps.
* Add back implementations for call/creates.