### PR TITLE
Refactor: GasedMachine

### DIFF
--- a/interpreter/src/eval/mod.rs
+++ b/interpreter/src/eval/mod.rs
@@ -6,7 +6,7 @@ mod misc;
 mod system;
 
 use crate::{
-	CallCreateTrap, ExitException, ExitResult, ExitSucceed, Machine, Opcode, RuntimeHandler,
+	CallCreateTrap, ExitException, ExitResult, ExitSucceed, Machine, Opcode, RuntimeBackend,
 	RuntimeState,
 };
 use core::marker::PhantomData;
@@ -179,7 +179,7 @@ impl<S, H, Tr> Etable<S, H, Tr> {
 	}
 }
 
-impl<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr: CallCreateTrap> Etable<S, H, Tr> {
+impl<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr: CallCreateTrap> Etable<S, H, Tr> {
 	/// Runtime Etable.
 	pub const fn runtime() -> Etable<S, H, Tr> {
 		let mut table = Self::core();
@@ -1217,7 +1217,7 @@ fn eval_unknown<S, H, Tr>(
 	Control::Exit(ExitException::InvalidOpcode(opcode).into())
 }
 
-fn eval_sha3<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_sha3<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
@@ -1226,7 +1226,7 @@ fn eval_sha3<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::sha3(machine)
 }
 
-fn eval_address<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_address<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
@@ -1235,7 +1235,7 @@ fn eval_address<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::address(machine)
 }
 
-fn eval_balance<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_balance<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1244,7 +1244,7 @@ fn eval_balance<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::balance(machine, handle)
 }
 
-fn eval_selfbalance<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_selfbalance<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1253,7 +1253,7 @@ fn eval_selfbalance<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::selfbalance(machine, handle)
 }
 
-fn eval_origin<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_origin<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1262,7 +1262,7 @@ fn eval_origin<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::origin(machine, handle)
 }
 
-fn eval_caller<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_caller<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
@@ -1271,7 +1271,7 @@ fn eval_caller<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::caller(machine)
 }
 
-fn eval_callvalue<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_callvalue<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
@@ -1280,7 +1280,7 @@ fn eval_callvalue<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::callvalue(machine)
 }
 
-fn eval_gasprice<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_gasprice<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1289,7 +1289,7 @@ fn eval_gasprice<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::gasprice(machine, handle)
 }
 
-fn eval_extcodesize<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_extcodesize<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1298,7 +1298,7 @@ fn eval_extcodesize<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::extcodesize(machine, handle)
 }
 
-fn eval_extcodehash<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_extcodehash<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1307,7 +1307,7 @@ fn eval_extcodehash<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::extcodehash(machine, handle)
 }
 
-fn eval_extcodecopy<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_extcodecopy<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1316,7 +1316,7 @@ fn eval_extcodecopy<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::extcodecopy(machine, handle)
 }
 
-fn eval_returndatasize<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_returndatasize<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
@@ -1325,7 +1325,7 @@ fn eval_returndatasize<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::returndatasize(machine)
 }
 
-fn eval_returndatacopy<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_returndatacopy<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	_handle: &mut H,
 	_opcode: Opcode,
@@ -1334,7 +1334,7 @@ fn eval_returndatacopy<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::returndatacopy(machine)
 }
 
-fn eval_blockhash<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_blockhash<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1343,7 +1343,7 @@ fn eval_blockhash<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::blockhash(machine, handle)
 }
 
-fn eval_coinbase<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_coinbase<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1352,7 +1352,7 @@ fn eval_coinbase<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::coinbase(machine, handle)
 }
 
-fn eval_timestamp<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_timestamp<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1361,7 +1361,7 @@ fn eval_timestamp<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::timestamp(machine, handle)
 }
 
-fn eval_number<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_number<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1370,7 +1370,7 @@ fn eval_number<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::number(machine, handle)
 }
 
-fn eval_difficulty<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_difficulty<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1379,7 +1379,7 @@ fn eval_difficulty<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::prevrandao(machine, handle)
 }
 
-fn eval_gaslimit<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_gaslimit<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1388,7 +1388,7 @@ fn eval_gaslimit<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::gaslimit(machine, handle)
 }
 
-fn eval_sload<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_sload<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1397,7 +1397,7 @@ fn eval_sload<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::sload(machine, handle)
 }
 
-fn eval_sstore<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_sstore<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1406,7 +1406,7 @@ fn eval_sstore<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::sstore(machine, handle)
 }
 
-fn eval_gas<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_gas<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1415,7 +1415,7 @@ fn eval_gas<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::gas(machine, handle)
 }
 
-fn eval_log0<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_log0<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1424,7 +1424,7 @@ fn eval_log0<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::log(machine, 0, handle)
 }
 
-fn eval_log1<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_log1<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1433,7 +1433,7 @@ fn eval_log1<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::log(machine, 1, handle)
 }
 
-fn eval_log2<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_log2<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1442,7 +1442,7 @@ fn eval_log2<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::log(machine, 2, handle)
 }
 
-fn eval_log3<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_log3<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1451,7 +1451,7 @@ fn eval_log3<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::log(machine, 3, handle)
 }
 
-fn eval_log4<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_log4<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1460,7 +1460,7 @@ fn eval_log4<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::log(machine, 4, handle)
 }
 
-fn eval_suicide<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_suicide<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1469,7 +1469,7 @@ fn eval_suicide<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::suicide(machine, handle)
 }
 
-fn eval_chainid<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_chainid<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,
@@ -1478,7 +1478,7 @@ fn eval_chainid<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	self::system::chainid(machine, handle)
 }
 
-fn eval_basefee<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+fn eval_basefee<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handle: &mut H,
 	_opcode: Opcode,

--- a/interpreter/src/eval/system.rs
+++ b/interpreter/src/eval/system.rs
@@ -1,5 +1,5 @@
 use super::Control;
-use crate::{ExitException, ExitFatal, ExitSucceed, Machine, RuntimeHandler, RuntimeState};
+use crate::{ExitException, ExitFatal, ExitSucceed, Machine, RuntimeBackend, RuntimeState};
 use alloc::vec::Vec;
 use primitive_types::{H256, U256};
 use sha3::{Digest, Keccak256};
@@ -23,7 +23,7 @@ pub fn sha3<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<Tr>
 	Control::Continue
 }
 
-pub fn chainid<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn chainid<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -39,7 +39,7 @@ pub fn address<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<
 	Control::Continue
 }
 
-pub fn balance<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn balance<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
 ) -> Control<Tr> {
@@ -50,7 +50,7 @@ pub fn balance<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn selfbalance<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn selfbalance<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -62,7 +62,7 @@ pub fn selfbalance<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn origin<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn origin<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -92,7 +92,7 @@ pub fn callvalue<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Contro
 	Control::Continue
 }
 
-pub fn gasprice<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn gasprice<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -103,7 +103,7 @@ pub fn gasprice<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn basefee<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn basefee<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -114,7 +114,7 @@ pub fn basefee<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn extcodesize<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn extcodesize<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
 ) -> Control<Tr> {
@@ -126,7 +126,7 @@ pub fn extcodesize<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn extcodehash<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn extcodehash<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
 ) -> Control<Tr> {
@@ -138,7 +138,7 @@ pub fn extcodehash<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn extcodecopy<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn extcodecopy<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
 ) -> Control<Tr> {
@@ -190,7 +190,7 @@ pub fn returndatacopy<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> C
 	}
 }
 
-pub fn blockhash<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn blockhash<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -200,7 +200,7 @@ pub fn blockhash<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn coinbase<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn coinbase<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -208,7 +208,7 @@ pub fn coinbase<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn timestamp<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn timestamp<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -216,7 +216,7 @@ pub fn timestamp<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn number<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn number<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -224,7 +224,7 @@ pub fn number<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn difficulty<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn difficulty<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -232,7 +232,7 @@ pub fn difficulty<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn prevrandao<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn prevrandao<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -244,7 +244,7 @@ pub fn prevrandao<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	}
 }
 
-pub fn gaslimit<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn gaslimit<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &H,
 ) -> Control<Tr> {
@@ -252,7 +252,7 @@ pub fn gaslimit<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn sload<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn sload<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
 ) -> Control<Tr> {
@@ -264,7 +264,7 @@ pub fn sload<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	Control::Continue
 }
 
-pub fn sstore<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn sstore<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
 ) -> Control<Tr> {
@@ -277,16 +277,16 @@ pub fn sstore<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	}
 }
 
-pub fn gas<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn gas<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
-	handler: &H,
+	_handler: &H,
 ) -> Control<Tr> {
-	push_u256!(machine, handler.gas());
+	push_u256!(machine, machine.state.as_ref().gas);
 
 	Control::Continue
 }
 
-pub fn log<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn log<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	n: u8,
 	handler: &mut H,
@@ -319,7 +319,7 @@ pub fn log<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
 	}
 }
 
-pub fn suicide<S: AsRef<RuntimeState>, H: RuntimeHandler, Tr>(
+pub fn suicide<S: AsRef<RuntimeState>, H: RuntimeBackend, Tr>(
 	machine: &mut Machine<S>,
 	handler: &mut H,
 ) -> Control<Tr> {

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -20,9 +20,7 @@ pub use crate::error::{Capture, ExitError, ExitException, ExitFatal, ExitResult,
 pub use crate::eval::{Control, Efn, Etable};
 pub use crate::memory::Memory;
 pub use crate::opcode::Opcode;
-pub use crate::runtime::{
-	CallCreateTrap, Context, RuntimeBackend, RuntimeGasometer, RuntimeHandler, RuntimeState,
-};
+pub use crate::runtime::{CallCreateTrap, Context, RuntimeBackend, RuntimeState};
 pub use crate::stack::Stack;
 pub use crate::valids::Valids;
 

--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -8,6 +8,8 @@ pub struct RuntimeState {
 	pub context: Context,
 	/// Return data buffer.
 	pub retbuf: Vec<u8>,
+	/// Current gas.
+	pub gas: U256,
 }
 
 impl AsRef<RuntimeState> for RuntimeState {
@@ -96,100 +98,3 @@ pub trait RuntimeBackend {
 	/// Mark an address to be deleted, with funds transferred to target.
 	fn mark_delete(&mut self, address: H160, target: H160) -> Result<(), ExitError>;
 }
-
-pub trait RuntimeGasometer {
-	/// Get the gas left value.
-	fn gas(&self) -> U256;
-}
-
-/// Handler trait for runtime.
-///
-/// The handler is generally expected to be a `(backend, gasometer)` tuple, with extensions added
-/// to `backend`.
-pub trait RuntimeHandler: RuntimeBackend + RuntimeGasometer {}
-
-impl<'b, 'g, G: RuntimeGasometer, H: RuntimeBackend> RuntimeBackend for (&'b mut G, &'g mut H) {
-	fn block_hash(&self, number: U256) -> H256 {
-		self.1.block_hash(number)
-	}
-	fn block_number(&self) -> U256 {
-		self.1.block_number()
-	}
-	fn block_coinbase(&self) -> H160 {
-		self.1.block_coinbase()
-	}
-	fn block_timestamp(&self) -> U256 {
-		self.1.block_timestamp()
-	}
-	fn block_difficulty(&self) -> U256 {
-		self.1.block_difficulty()
-	}
-	fn block_randomness(&self) -> Option<H256> {
-		self.1.block_randomness()
-	}
-	fn block_gas_limit(&self) -> U256 {
-		self.1.block_gas_limit()
-	}
-	fn block_base_fee_per_gas(&self) -> U256 {
-		self.1.block_base_fee_per_gas()
-	}
-	fn chain_id(&self) -> U256 {
-		self.1.chain_id()
-	}
-	fn gas_price(&self) -> U256 {
-		self.1.gas_price()
-	}
-	fn origin(&self) -> H160 {
-		self.1.origin()
-	}
-
-	fn balance(&self, address: H160) -> U256 {
-		self.1.balance(address)
-	}
-	fn code_size(&self, address: H160) -> U256 {
-		self.1.code_size(address)
-	}
-	fn code_hash(&self, address: H160) -> H256 {
-		self.1.code_hash(address)
-	}
-	fn code(&self, address: H160) -> Vec<u8> {
-		self.1.code(address)
-	}
-	fn storage(&self, address: H160, index: H256) -> H256 {
-		self.1.storage(address, index)
-	}
-	fn original_storage(&self, address: H160, index: H256) -> H256 {
-		self.1.original_storage(address, index)
-	}
-
-	fn exists(&self, address: H160) -> bool {
-		self.1.exists(address)
-	}
-	fn deleted(&self, address: H160) -> bool {
-		self.1.deleted(address)
-	}
-	fn is_cold(&self, address: H160, index: Option<H256>) -> bool {
-		self.1.is_cold(address, index)
-	}
-	fn mark_hot(&mut self, address: H160, index: Option<H256>) -> Result<(), ExitError> {
-		self.1.mark_hot(address, index)
-	}
-	fn set_storage(&mut self, address: H160, index: H256, value: H256) -> Result<(), ExitError> {
-		self.1.set_storage(address, index, value)
-	}
-
-	fn log(&mut self, address: H160, topics: Vec<H256>, data: Vec<u8>) -> Result<(), ExitError> {
-		self.1.log(address, topics, data)
-	}
-	fn mark_delete(&mut self, address: H160, target: H160) -> Result<(), ExitError> {
-		self.1.mark_delete(address, target)
-	}
-}
-
-impl<'b, 'g, G: RuntimeGasometer, H: RuntimeBackend> RuntimeGasometer for (&'b mut G, &'g mut H) {
-	fn gas(&self) -> U256 {
-		self.0.gas()
-	}
-}
-
-impl<'b, 'g, G: RuntimeGasometer, H: RuntimeBackend> RuntimeHandler for (&'b mut G, &'g mut H) {}

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -1,6 +1,6 @@
 use evm_interpreter::{
 	Capture, Context, Control, Etable, ExitError, ExitSucceed, Machine, Opcode, RuntimeBackend,
-	RuntimeGasometer, RuntimeHandler, RuntimeState,
+	RuntimeState,
 };
 use primitive_types::{H160, H256, U256};
 use std::rc::Rc;
@@ -135,14 +135,6 @@ impl<'a> RuntimeBackend for UnimplementedHandler {
 	}
 }
 
-impl<'a> RuntimeGasometer for UnimplementedHandler {
-	fn gas(&self) -> U256 {
-		unimplemented!()
-	}
-}
-
-impl<'a> RuntimeHandler for UnimplementedHandler {}
-
 static RUNTIME_ETABLE: Etable<RuntimeState, UnimplementedHandler, Opcode> = Etable::runtime();
 
 #[test]
@@ -163,6 +155,7 @@ fn etable_runtime() {
 				apparent_value: U256::default(),
 			},
 			retbuf: Vec::new(),
+			gas: U256::zero(),
 		},
 	);
 

--- a/src/invoker.rs
+++ b/src/invoker.rs
@@ -1,4 +1,4 @@
-use crate::{Capture, ExitError, ExitResult, Machine};
+use crate::{Capture, ExitError, ExitResult, GasedMachine};
 
 pub trait Invoker<S, G, H, Tr> {
 	type Interrupt;
@@ -7,18 +7,16 @@ pub trait Invoker<S, G, H, Tr> {
 	fn exit_trap_stack(
 		&self,
 		result: ExitResult,
-		child: Machine<S>,
+		child: GasedMachine<S, G>,
 		trap_data: Self::CallCreateTrapData,
-		machine: &mut Machine<S>,
-		gasometer: &mut G,
+		parent: &mut GasedMachine<S, G>,
 		handler: &mut H,
 	) -> Result<(), ExitError>;
 
 	fn prepare_trap(
 		&self,
 		trap: Tr,
-		machine: &mut Machine<S>,
-		gasometer: &mut G,
+		machine: &mut GasedMachine<S, G>,
 		handler: &mut H,
 		depth: usize,
 	) -> Capture<Result<Self::CallCreateTrapData, ExitError>, Self::Interrupt>;
@@ -27,5 +25,5 @@ pub trait Invoker<S, G, H, Tr> {
 		&self,
 		trap_data: &Self::CallCreateTrapData,
 		handler: &mut H,
-	) -> Result<(Machine<S>, G, bool), ExitError>;
+	) -> Result<GasedMachine<S, G>, ExitError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,5 @@ pub use evm_interpreter::*;
 
 pub use crate::backend::{TransactionalBackend, TransactionalMergeStrategy};
 pub use crate::call_stack::{execute, CallStack};
-pub use crate::gasometer::{run_with_gasometer, Gas, Gasometer, GasometerMergeStrategy};
+pub use crate::gasometer::{Gas, GasedMachine, Gasometer, GasometerMergeStrategy};
 pub use crate::invoker::Invoker;

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -5,7 +5,7 @@ mod utils;
 use crate::standard::Config;
 use crate::{
 	ExitError, ExitException, Gasometer as GasometerT, GasometerMergeStrategy, Machine, Opcode,
-	RuntimeBackend, RuntimeGasometer, RuntimeState, Stack,
+	RuntimeBackend, RuntimeState, Stack,
 };
 use core::cmp::max;
 use primitive_types::{H160, H256, U256};
@@ -56,12 +56,6 @@ impl<'config> Gasometer<'config> {
 			self.used_gas += cost;
 			Ok(())
 		}
-	}
-}
-
-impl<'config> RuntimeGasometer for Gasometer<'config> {
-	fn gas(&self) -> U256 {
-		U256::from(self.gas())
 	}
 }
 


### PR DESCRIPTION
This refactor moves the `GAS` opcode to use machine state, instead of machine handle, and add a new `GasedMachine` struct to hold `Machine`, `Gasometer` and the `is_static` flag together.