### PR TITLE
Reverse the order of backend and is_static in gasometer

### DIFF
--- a/src/gasometer.rs
+++ b/src/gasometer.rs
@@ -31,8 +31,8 @@ pub trait Gasometer<S, H>: Sized {
 	fn record_stepn(
 		&mut self,
 		machine: &Machine<S>,
-		backend: &H,
 		is_static: bool,
+		backend: &H,
 	) -> Result<usize, ExitError>;
 	fn record_codedeposit(&mut self, len: usize) -> Result<(), ExitError>;
 	fn gas(&self) -> Self::Gas;
@@ -58,7 +58,7 @@ impl<S: AsMut<RuntimeState>, G> GasedMachine<S, G> {
 		loop {
 			match self
 				.gasometer
-				.record_stepn(&self.machine, handler, self.is_static)
+				.record_stepn(&self.machine, self.is_static, handler)
 			{
 				Ok(stepn) => {
 					self.machine.state.as_mut().gas = self.gasometer.gas().into();

--- a/src/standard/gasometer/mod.rs
+++ b/src/standard/gasometer/mod.rs
@@ -76,8 +76,8 @@ impl<'config, S: AsRef<RuntimeState>, H: RuntimeBackend> GasometerT<S, H> for Ga
 	fn record_stepn(
 		&mut self,
 		machine: &Machine<S>,
-		handler: &H,
 		is_static: bool,
+		handler: &H,
 	) -> Result<usize, ExitError> {
 		self.perform(|gasometer| {
 			let opcode = machine.peek_opcode().ok_or(ExitException::OutOfGas)?;


### PR DESCRIPTION
Follow the ordering as it is elsewhere.