### PR TITLE
Generalize machine run/step in call stack

### DIFF
--- a/jsontests/src/run.rs
+++ b/jsontests/src/run.rs
@@ -5,7 +5,7 @@ use evm::backend::in_memory::{
 };
 use evm::standard::{Config, Etable, Gasometer, Invoker, TransactArgs};
 use evm::utils::u256_to_h256;
-use evm::{Capture, RuntimeState};
+use evm::{Capture, GasedMachine};
 use primitive_types::U256;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -59,7 +59,7 @@ pub fn run_test(_filename: &str, _test_name: &str, test: Test, debug: bool) -> R
 		.collect::<BTreeMap<_, _>>();
 
 	let etable = Etable::runtime();
-	let invoker = Invoker::new(&config);
+	let invoker = Invoker::<_, Gasometer, _, _, _>::new(&config, &etable);
 	let args = TransactArgs::Call {
 		caller: test.transaction.sender,
 		address: test.transaction.to,
@@ -93,36 +93,27 @@ pub fn run_test(_filename: &str, _test_name: &str, test: Test, debug: bool) -> R
 	let mut step_backend = run_backend.clone();
 
 	// Run
-	let run_result = evm::transact::<RuntimeState, Gasometer, _, _, _, _>(
-		args.clone(),
-		Some(4),
-		&mut run_backend,
-		&invoker,
-		&etable,
-	);
+	let run_result = evm::transact(args.clone(), Some(4), &mut run_backend, &invoker);
 	run_backend.layers[0].clear_pending();
 
 	// Step
 	if debug {
-		let _step_result = evm::HeapTransact::<RuntimeState, Gasometer, _, _, _>::new(
-			args,
-			&invoker,
-			&mut step_backend,
-		)
-		.and_then(|mut stepper| loop {
-			{
-				let machine = stepper.last_machine()?;
-				println!(
-					"pc: {}, opcode: {:?}, gas: 0x{:x}",
-					machine.machine.position(),
-					machine.machine.peek_opcode(),
-					machine.gasometer.gas(),
-				);
-			}
-			if let Err(Capture::Exit(result)) = stepper.step(&etable) {
-				break result;
-			}
-		});
+		let _step_result = evm::HeapTransact::new(args, &invoker, &mut step_backend).and_then(
+			|mut stepper| loop {
+				{
+					let machine: &GasedMachine<_, Gasometer> = stepper.last_machine()?;
+					println!(
+						"pc: {}, opcode: {:?}, gas: 0x{:x}",
+						machine.machine.position(),
+						machine.machine.peek_opcode(),
+						machine.gasometer.gas(),
+					);
+				}
+				if let Err(Capture::Exit(result)) = stepper.step() {
+					break result;
+				}
+			},
+		);
 		step_backend.layers[0].clear_pending();
 	}
 

--- a/src/invoker.rs
+++ b/src/invoker.rs
@@ -1,6 +1,7 @@
-use crate::{Capture, ExitError, ExitResult, GasedMachine};
+use crate::{Capture, ExitError, ExitResult};
 
-pub trait Invoker<S, G, H, Tr> {
+pub trait Invoker<H, Tr> {
+	type Machine;
 	type Interrupt;
 
 	type TransactArgs;
@@ -8,33 +9,41 @@ pub trait Invoker<S, G, H, Tr> {
 	type TransactValue;
 	type SubstackInvoke;
 
+	fn run_machine(&self, machine: &mut Self::Machine, handler: &mut H) -> Capture<ExitResult, Tr>;
+	fn step_machine(
+		&self,
+		machine: &mut Self::Machine,
+		handler: &mut H,
+	) -> Result<(), Capture<ExitResult, Tr>>;
+
 	fn new_transact(
 		&self,
 		args: Self::TransactArgs,
 		handler: &mut H,
-	) -> Result<(Self::TransactInvoke, GasedMachine<S, G>), ExitError>;
+	) -> Result<(Self::TransactInvoke, Self::Machine), ExitError>;
+
 	fn finalize_transact(
 		&self,
 		invoke: &Self::TransactInvoke,
 		exit: ExitResult,
-		machine: GasedMachine<S, G>,
+		machine: Self::Machine,
 		handler: &mut H,
 	) -> Result<Self::TransactValue, ExitError>;
 
 	fn exit_substack(
 		&self,
 		result: ExitResult,
-		child: GasedMachine<S, G>,
+		child: Self::Machine,
 		trap_data: Self::SubstackInvoke,
-		parent: &mut GasedMachine<S, G>,
+		parent: &mut Self::Machine,
 		handler: &mut H,
 	) -> Result<(), ExitError>;
 
 	fn enter_substack(
 		&self,
 		trap: Tr,
-		machine: &mut GasedMachine<S, G>,
+		machine: &mut Self::Machine,
 		handler: &mut H,
 		depth: usize,
-	) -> Capture<Result<(Self::SubstackInvoke, GasedMachine<S, G>), ExitError>, Self::Interrupt>;
+	) -> Capture<Result<(Self::SubstackInvoke, Self::Machine), ExitError>, Self::Interrupt>;
 }


### PR DESCRIPTION
Prepare for the new precompile design.

The idea is that because many use cases require precompile extensively, we might just make precompiles behave the same as a normal interpreter machine -- it actually pushes call stack, has gasometers and access to the whole handler. This gives a lot more flexibility in custom precompile designs.