### PR TITLE
Expose parent machine information in substate creation

### DIFF
--- a/src/standard/invoker/routines.rs
+++ b/src/standard/invoker/routines.rs
@@ -1,9 +1,9 @@
 use super::{CallTrapData, CreateTrapData, Precompile, ResolvedCode, SubstackInvoke};
-use crate::standard::{Config, MergeableRuntimeState};
+use crate::standard::Config;
 use crate::{
 	ExitError, ExitException, ExitResult, GasedMachine, Gasometer as GasometerT, InvokerControl,
-	Machine, MergeStrategy, Opcode, RuntimeBackend, RuntimeEnvironment, StaticGasometer,
-	TransactionalBackend, Transfer,
+	Machine, MergeStrategy, Opcode, RuntimeBackend, RuntimeEnvironment, RuntimeState,
+	StaticGasometer, TransactionalBackend, Transfer,
 };
 use alloc::rc::Rc;
 use primitive_types::{H160, U256};
@@ -19,7 +19,7 @@ pub fn make_enter_call_machine<'config, 'precompile, S, G, H, P>(
 	handler: &mut H,
 ) -> Result<InvokerControl<GasedMachine<S, G>, (ExitResult, (S, G, Vec<u8>))>, ExitError>
 where
-	S: MergeableRuntimeState,
+	S: AsRef<RuntimeState>,
 	G: GasometerT<S, H>,
 	H: RuntimeEnvironment + RuntimeBackend + TransactionalBackend,
 	P: Precompile<S, G, H>,
@@ -67,7 +67,7 @@ pub fn make_enter_create_machine<'config, S, G, H>(
 	handler: &mut H,
 ) -> Result<GasedMachine<S, G>, ExitError>
 where
-	S: MergeableRuntimeState,
+	S: AsRef<RuntimeState>,
 	G: GasometerT<S, H>,
 	H: RuntimeEnvironment + RuntimeBackend + TransactionalBackend,
 {
@@ -125,7 +125,7 @@ pub fn enter_call_substack<'config, 'precompile, S, G, H, P>(
 	ExitError,
 >
 where
-	S: MergeableRuntimeState,
+	S: AsRef<RuntimeState>,
 	G: GasometerT<S, H>,
 	H: RuntimeEnvironment + RuntimeBackend + TransactionalBackend,
 	P: Precompile<S, G, H>,
@@ -166,7 +166,7 @@ pub fn enter_create_substack<'config, S, G, H>(
 	handler: &mut H,
 ) -> Result<(SubstackInvoke, GasedMachine<S, G>), ExitError>
 where
-	S: MergeableRuntimeState,
+	S: AsRef<RuntimeState>,
 	G: GasometerT<S, H>,
 	H: RuntimeEnvironment + RuntimeBackend + TransactionalBackend,
 {
@@ -225,7 +225,6 @@ pub fn deploy_create_code<'config, S, G, H>(
 	handler: &mut H,
 ) -> Result<(), ExitError>
 where
-	S: MergeableRuntimeState,
 	G: GasometerT<S, H>,
 	H: RuntimeEnvironment + RuntimeBackend + TransactionalBackend,
 {

--- a/src/standard/mod.rs
+++ b/src/standard/mod.rs
@@ -11,15 +11,17 @@ pub type Efn<H> = crate::Efn<crate::RuntimeState, H, crate::Opcode>;
 pub type Etable<H, F = Efn<H>> = crate::Etable<crate::RuntimeState, H, crate::Opcode, F>;
 pub type GasedMachine<G> = crate::GasedMachine<crate::RuntimeState, G>;
 
-pub trait MergeableRuntimeState: AsRef<crate::RuntimeState> + AsMut<crate::RuntimeState> {
-	fn substate(&self, runtime: crate::RuntimeState) -> Self;
+pub trait MergeableRuntimeState<M>:
+	AsRef<crate::RuntimeState> + AsMut<crate::RuntimeState>
+{
+	fn substate(&self, runtime: crate::RuntimeState, parent: &M) -> Self;
 	fn merge(&mut self, substate: Self, strategy: crate::MergeStrategy);
 	fn new_transact_call(runtime: crate::RuntimeState) -> Self;
 	fn new_transact_create(runtime: crate::RuntimeState) -> Self;
 }
 
-impl MergeableRuntimeState for crate::RuntimeState {
-	fn substate(&self, runtime: crate::RuntimeState) -> Self {
+impl<M> MergeableRuntimeState<M> for crate::RuntimeState {
+	fn substate(&self, runtime: crate::RuntimeState, _parent: &M) -> Self {
 		runtime
 	}
 	fn merge(&mut self, _substate: Self, _strategy: crate::MergeStrategy) {}


### PR DESCRIPTION
With the new generics we can actually easily support use cases like #175. One would create a wrap structure over `RuntimeState`. The parent machine (together with the parent state, and the gasometer) is accessible in `MergeableRuntimeState::substate`. One can then pass information like parent used gas over into the custom wrapping struct.