### PR TITLE
Don't use InvokerControl for precompile

### DIFF
--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -27,10 +27,7 @@ pub use crate::simple::{ECRecover, Identity, Ripemd160, Sha256};
 
 use alloc::vec::Vec;
 use evm::standard::{CodeResolver, Config, Precompile, ResolvedCode};
-use evm::{
-	ExitError, ExitException, ExitResult, GasedMachine, InvokerControl, RuntimeBackend,
-	RuntimeState, StaticGasometer,
-};
+use evm::{ExitError, ExitException, ExitResult, RuntimeBackend, RuntimeState, StaticGasometer};
 
 use primitive_types::H160;
 
@@ -62,7 +59,7 @@ impl<S: AsRef<RuntimeState>, G: StaticGasometer, H> Precompile<S, G, H> for Stan
 		state: S,
 		mut gasometer: G,
 		_handler: &mut H,
-	) -> InvokerControl<GasedMachine<S, G>, (ExitResult, (S, G, Vec<u8>))> {
+	) -> (ExitResult, (S, G, Vec<u8>)) {
 		let (exit, retval) = match self {
 			Self::ECRecover => ECRecover.execute(input, state.as_ref(), &mut gasometer),
 			Self::Sha256 => Sha256.execute(input, state.as_ref(), &mut gasometer),
@@ -75,7 +72,7 @@ impl<S: AsRef<RuntimeState>, G: StaticGasometer, H> Precompile<S, G, H> for Stan
 			Self::Blake2F => Blake2F.execute(input, state.as_ref(), &mut gasometer),
 		};
 
-		InvokerControl::DirectExit((exit, (state, gasometer, retval)))
+		(exit, (state, gasometer, retval))
 	}
 }
 

--- a/src/standard/invoker/mod.rs
+++ b/src/standard/invoker/mod.rs
@@ -112,7 +112,7 @@ pub trait Precompile<S, G, H> {
 		state: S,
 		gasometer: G,
 		handler: &mut H,
-	) -> InvokerControl<GasedMachine<S, G>, (ExitResult, (S, G, Vec<u8>))>;
+	) -> (ExitResult, (S, G, Vec<u8>));
 }
 
 impl<S, G, H> Precompile<S, G, H> for Infallible {
@@ -122,7 +122,7 @@ impl<S, G, H> Precompile<S, G, H> for Infallible {
 		_state: S,
 		_gasometer: G,
 		_handler: &mut H,
-	) -> InvokerControl<GasedMachine<S, G>, (ExitResult, (S, G, Vec<u8>))> {
+	) -> (ExitResult, (S, G, Vec<u8>)) {
 		match *self {}
 	}
 }

--- a/src/standard/invoker/routines.rs
+++ b/src/standard/invoker/routines.rs
@@ -56,9 +56,9 @@ where
 				is_static,
 			}))
 		}
-		ResolvedCode::Precompile(precompile) => {
-			Ok(precompile.execute(&input, state, gasometer, handler))
-		}
+		ResolvedCode::Precompile(precompile) => Ok(InvokerControl::DirectExit(
+			precompile.execute(&input, state, gasometer, handler),
+		)),
 	}
 }
 


### PR DESCRIPTION
We can do #106 without that already, simply used `ResolvedCode` to generate the code!

I therefore would prefer to remove that InvokerControl, because complicated types will be hard to use, and eventually confusing. We should prefer simpler when possible.