### PR TITLE
Better trap handling

### DIFF
--- a/interpreter/src/etable.rs
+++ b/interpreter/src/etable.rs
@@ -1,6 +1,6 @@
 use crate::{
-	eval::*, CallCreateTrap, ExitResult, GasState, Machine, Opcode, RuntimeBackend,
-	RuntimeEnvironment, RuntimeState,
+	call_create::CallCreateTrap, eval::*, ExitResult, GasState, Machine, Opcode, RuntimeBackend,
+	RuntimeEnvironment, RuntimeState, TrapConstruct,
 };
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
@@ -236,7 +236,7 @@ impl<S, H, Tr> Etable<S, H, Tr> {
 	}
 }
 
-impl<S, H: RuntimeEnvironment + RuntimeBackend, Tr: CallCreateTrap> Etable<S, H, Tr>
+impl<S, H: RuntimeEnvironment + RuntimeBackend, Tr: TrapConstruct<CallCreateTrap>> Etable<S, H, Tr>
 where
 	S: AsRef<RuntimeState> + GasState,
 {

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -15,6 +15,7 @@ mod memory;
 mod opcode;
 mod runtime;
 mod stack;
+mod trap;
 pub mod utils;
 mod valids;
 
@@ -24,10 +25,11 @@ pub use crate::interpreter::{EtableInterpreter, Interpreter, StepInterpreter};
 pub use crate::memory::Memory;
 pub use crate::opcode::Opcode;
 pub use crate::runtime::{
-	CallCreateTrap, Context, GasState, Log, RuntimeBackend, RuntimeBaseBackend, RuntimeEnvironment,
-	RuntimeState, TransactionContext, Transfer,
+	Context, GasState, Log, RuntimeBackend, RuntimeBaseBackend, RuntimeEnvironment, RuntimeState,
+	TransactionContext, Transfer,
 };
 pub use crate::stack::Stack;
+pub use crate::trap::{TrapConstruct, TrapConsume};
 pub use crate::valids::Valids;
 
 use alloc::rc::Rc;

--- a/interpreter/src/runtime.rs
+++ b/interpreter/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::{ExitError, Opcode};
+use crate::ExitError;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
 use primitive_types::{H160, H256, U256};
@@ -73,16 +73,6 @@ pub struct Log {
 	pub address: H160,
 	pub topics: Vec<H256>,
 	pub data: Vec<u8>,
-}
-
-pub trait CallCreateTrap: Sized {
-	fn call_create_trap(opcode: Opcode) -> Self;
-}
-
-impl CallCreateTrap for Opcode {
-	fn call_create_trap(opcode: Opcode) -> Self {
-		opcode
-	}
 }
 
 pub trait RuntimeEnvironment {

--- a/interpreter/src/trap.rs
+++ b/interpreter/src/trap.rs
@@ -1,0 +1,9 @@
+pub trait TrapConstruct<T> {
+	fn construct(v: T) -> Self;
+}
+
+pub trait TrapConsume<T> {
+	type Rest;
+
+	fn consume(self) -> Result<T, Self::Rest>;
+}

--- a/interpreter/tests/usability.rs
+++ b/interpreter/tests/usability.rs
@@ -1,7 +1,7 @@
 use evm_interpreter::{
-	Capture, Context, Control, Etable, EtableInterpreter, ExitError, ExitSucceed, Interpreter, Log,
-	Machine, Opcode, RuntimeBackend, RuntimeBaseBackend, RuntimeEnvironment, RuntimeState,
-	TransactionContext,
+	call_create::CallCreateTrap, Capture, Context, Control, Etable, EtableInterpreter, ExitError,
+	ExitSucceed, Interpreter, Log, Machine, Opcode, RuntimeBackend, RuntimeBaseBackend,
+	RuntimeEnvironment, RuntimeState, TransactionContext,
 };
 use primitive_types::{H160, H256, U256};
 use std::rc::Rc;
@@ -167,7 +167,8 @@ impl RuntimeBackend for UnimplementedHandler {
 	}
 }
 
-static RUNTIME_ETABLE: Etable<RuntimeState, UnimplementedHandler, Opcode> = Etable::runtime();
+static RUNTIME_ETABLE: Etable<RuntimeState, UnimplementedHandler, CallCreateTrap> =
+	Etable::runtime();
 
 #[test]
 fn etable_runtime() {

--- a/src/standard/mod.rs
+++ b/src/standard/mod.rs
@@ -22,11 +22,11 @@ use primitive_types::{H160, H256, U256};
 pub type Machine<'config> = crate::Machine<State<'config>>;
 
 /// Standard Etable opcode handle function.
-pub type Efn<'config, H> = crate::Efn<State<'config>, H, crate::Opcode>;
+pub type Efn<'config, H> = crate::Efn<State<'config>, H, crate::call_create::CallCreateTrap>;
 
 /// Standard Etable.
 pub type Etable<'config, H, F = Efn<'config, H>> =
-	crate::Etable<State<'config>, H, crate::Opcode, F>;
+	crate::Etable<State<'config>, H, crate::call_create::CallCreateTrap, F>;
 
 pub trait GasMutState: GasState {
 	fn record_gas(&mut self, gas: U256) -> Result<(), ExitError>;


### PR DESCRIPTION
Introduce two different traits `TrapConsume` and `TrapConstruct`.

`TrapConstruct` is self-explanatory -- given a base-type trap, it warps it to the top-level enum.

`TrapConsume` should be implemented on the top-level enum for all possibilities of trap handling orders, and reduce the type into `Rest`. For example, if a VM has three different types of traps -- `CallCreateTrap`, `dyn Future<Output = Control<Tr>>` for storage access, and `Interrupt`. Then `TrapConsume<CallCreateTrap>` should return an enum containing two other variants `dyn Future<Output = Control<Tr>>` and `Interrupt`, and so forth.