### PR TITLE
Properly return retval in TransactValue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! for the function.
 //!
 //! * Select an [Invoker]. The invoker defines all details of the execution
-//!   environment except the external backend. [standard::SimpleInvoker] is
+//!   environment except the external backend. [standard::Invoker] is
 //!   probably want you want if you are not extending EVM.
 //! * For the standard invoker, select a [standard::Config], which represents
 //!   different Ethereum hard forks.


### PR DESCRIPTION
For a CALL transaction, we should return the `retval`, because some RPC calls need it.