### PR TITLE
Init evm64 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ members = [
 	"jsontests",
 	"precompile",
 	"tracer",
+
+	"features/evm64",
 ]
 resolver = "2"
 

--- a/features/evm64/Cargo.toml
+++ b/features/evm64/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "evm-feature-evm64"
+version = "0.0.0-dev"
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+keywords = { workspace = true }
+
+[dependencies]
+evm = { path = "../.." }

--- a/features/evm64/src/eval.rs
+++ b/features/evm64/src/eval.rs
@@ -1,0 +1,9 @@
+use evm::interpreter::{etable::Control, machine::Machine};
+
+pub fn eval_add<S, H, Tr>(
+	_machine: &mut Machine<S>,
+	_handle: &mut H,
+	_position: usize,
+) -> Control<Tr> {
+	todo!()
+}

--- a/features/evm64/src/gasometer.rs
+++ b/features/evm64/src/gasometer.rs
@@ -1,0 +1,15 @@
+use evm::{
+	interpreter::{etable::Control, machine::Machine},
+	standard::GasometerState,
+};
+
+pub fn eval<'config, S, H, Tr>(
+	_machine: &mut Machine<S>,
+	_handler: &mut H,
+	_position: usize,
+) -> Control<Tr>
+where
+	S: AsRef<GasometerState<'config>> + AsMut<GasometerState<'config>>,
+{
+	todo!()
+}

--- a/features/evm64/src/lib.rs
+++ b/features/evm64/src/lib.rs
@@ -1,0 +1,38 @@
+//! # The EVM64 feature
+//!
+//! See [EIP-7937](https://eips.ethereum.org/EIPS/eip-7937).
+
+pub mod eval;
+mod gasometer;
+
+pub use crate::gasometer::eval as eval_gasometer;
+
+use evm::{
+	interpreter::{
+		etable::{Etable, MultiEfn, MultiEtable, Single},
+		opcode::Opcode,
+	},
+	standard::GasometerState,
+};
+
+pub const OPCODE_EVM64_MODE: Opcode = Opcode(0xc0);
+
+/// Append a normal `(gasometer, runtime)` etable with EVM64 gasometer and
+/// opcodes.
+pub fn etable<'config, S, H, Tr>(
+	orig: (Single<S, H, Tr>, Etable<S, H, Tr>),
+) -> (Etable<S, H, Tr>, MultiEtable<S, H, Tr>)
+where
+	S: AsRef<GasometerState<'config>> + AsMut<GasometerState<'config>>,
+{
+	let mut gasometer_etable = Etable::from(orig.0);
+	let mut eval_etable = MultiEtable::from(orig.1);
+
+	let mut mode_etable = Etable::none();
+	mode_etable[Opcode::ADD.as_usize()] = eval::eval_add;
+
+	gasometer_etable[OPCODE_EVM64_MODE.as_usize()] = eval_gasometer;
+	eval_etable[OPCODE_EVM64_MODE.as_usize()] = MultiEfn::Node(Box::new(mode_etable.into()));
+
+	(gasometer_etable, eval_etable)
+}


### PR DESCRIPTION
`rust-evm` allows customization of literally all aspects of EVM. As a result, new (unstable) features can be added / removed with ease without affecting any other parts of the code. This one initialize the template for `evm64` feature. The actual `eval` and `gasometer` etables are yet to be filled out.