### PR TITLE
Allow generic-array deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ evm-compat = { version = "0.1.0", path = "compat", default-features = false }
 
 [package]
 name = "evm"
-version = "1.0.0"
+version = "1.0.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-interpreter"
-version = "1.0.0"
+version = "1.0.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/interpreter/src/eval/system.rs
+++ b/interpreter/src/eval/system.rs
@@ -10,6 +10,7 @@ use crate::{
 	runtime::{GasState, Log, RuntimeBackend, RuntimeEnvironment, RuntimeState, Transfer},
 };
 
+#[allow(deprecated)]
 pub fn sha3<S: AsRef<RuntimeState>, Tr>(machine: &mut Machine<S>) -> Control<Tr> {
 	pop_u256!(machine, from, len);
 

--- a/interpreter/src/trap.rs
+++ b/interpreter/src/trap.rs
@@ -383,6 +383,7 @@ pub enum CreateScheme {
 
 impl CreateScheme {
 	/// Resolved address.
+	#[allow(deprecated)]
 	pub fn address<H: RuntimeBackend>(&self, handler: &H) -> H160 {
 		match self {
 			Self::Create2 {
@@ -474,6 +475,7 @@ impl CreateTrap {
 	}
 
 	/// Create a new `CREATE2` trap from the machine state.
+	#[allow(deprecated)]
 	pub fn new_create2_from<S: AsRef<RuntimeState> + AsMut<RuntimeState>>(
 		machine: &mut Machine<S>,
 	) -> Result<Self, ExitError> {

--- a/precompile/Cargo.toml
+++ b/precompile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-precompile"
-version = "1.0.0"
+version = "1.0.1"
 edition = { workspace = true }
 rust-version = "1.87.0"
 authors = { workspace = true }

--- a/precompile/src/simple.rs
+++ b/precompile/src/simple.rs
@@ -14,6 +14,7 @@ use crate::{PurePrecompile, linear_cost};
 pub struct ECRecover;
 
 impl<G: GasMutState> PurePrecompile<G> for ECRecover {
+	#[allow(deprecated)]
 	fn execute(&self, i: &[u8], gasometer: &mut G) -> (ExitResult, Vec<u8>) {
 		const COST_BASE: u64 = 3000;
 		const COST_WORD: u64 = 0;

--- a/src/standard/invoker/mod.rs
+++ b/src/standard/invoker/mod.rs
@@ -270,6 +270,7 @@ where
 	type TransactInvoke = TransactInvoke<'config>;
 	type SubstackInvoke = SubstackInvoke;
 
+	#[allow(deprecated)]
 	fn new_transact(
 		&self,
 		args: Self::TransactArgs,


### PR DESCRIPTION
Generic-array moved to v1.0, which some dependencies we use (particularly `digest`) hasn't got an update release. They added `deprecated` flag to the entire crate, which is problematic. We need to add `allow(deprecated)` tag whenever we use it.