### PR TITLE
Re-export `InvokerExit` so the `Invoker` trait can be implemented externally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/rust-ethereum/evm"
 keywords = ["no_std", "ethereum", "evm"]
 
 [workspace.dependencies]
-evm = { version = "1.1.0", path = ".", default-features = false }
+evm = { version = "1.1.1", path = ".", default-features = false }
 evm-interpreter = { version = "1.1.0", path = "interpreter", default-features = false }
 evm-precompile = { version = "1.0.0", path = "precompile", default-features = false }
 evm-mainnet = { version = "1.0.0", path = "mainnet", default-features = false }
@@ -30,7 +30,7 @@ evm-compat = { version = "0.1.0", path = "compat", default-features = false }
 
 [package]
 name = "evm"
-version = "1.1.0"
+version = "1.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/src/invoker.rs
+++ b/src/invoker.rs
@@ -9,9 +9,13 @@ pub enum InvokerControl<I, S> {
 	DirectExit(InvokerExit<S>),
 }
 
+/// The exit value of an invoker call, containing the result, substate, and return data.
 pub struct InvokerExit<S> {
+	/// The exit result.
 	pub result: ExitResult,
+	/// The substate, if available.
 	pub substate: Option<S>,
+	/// The return data.
 	pub retval: Vec<u8>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub use crate::{
 	call_stack::{HeapTransact, transact},
 	gasometer::GasMutState,
 	interpreter::uint,
-	invoker::{Invoker, InvokerControl},
+	invoker::{Invoker, InvokerControl, InvokerExit},
 };
 
 /// Merge strategy of a backend substate layer or a call stack gasometer layer.


### PR DESCRIPTION
Fixes #402 — `InvokerExit` was used in `Invoker` trait method signatures but not re-exported, making it impossible to implement the trait outside the crate. Bump version to 1.1.1.