### PR TITLE
test(evm-core): fix stale delegation.rs test module

### DIFF
--- a/core/src/delegation.rs
+++ b/core/src/delegation.rs
@@ -98,8 +98,8 @@ mod tests {
 		let bytes = designator.to_bytes();
 
 		assert!(is_delegation_designator(&bytes));
-		let extracted = Delegation::try_from(&bytes);
-		assert_eq!(extracted, Some(designator));
+		let extracted = Delegation::try_from(bytes.as_slice());
+		assert_eq!(extracted, Ok(designator));
 		assert_eq!(*extracted.unwrap().address(), address);
 	}
 
@@ -107,6 +107,9 @@ mod tests {
 	fn test_non_delegation_code() {
 		let regular_code = vec![0x60, 0x00]; // PUSH1 0
 		assert!(!is_delegation_designator(&regular_code));
-		assert_eq!(Delegation::try_from(&regular_code), None);
+		assert_eq!(
+			Delegation::try_from(regular_code.as_slice()),
+			Err(DelegationError::InvalidFormat)
+		);
 	}
 }


### PR DESCRIPTION
## Problem

`evm-core`'s `core/src/delegation.rs` has a `#[cfg(test)] mod tests` that does not compile:

- `Delegation::try_from(&bytes)` is called with `bytes: Vec<u8>` (so the argument is `&Vec<u8>`), but the impl is `TryFrom<&[u8]>` — trait selection does not deref-coerce `&Vec<u8>` to `&[u8]`.
- The assertions compare against `Some(..)` / `None`, but `try_from` returns `Result<Delegation, DelegationError>`.

The module has been broken since #367 first added the file — the test was written against an `Option`-returning draft of the `Delegation` API, while the merged impl returns `Result` via `TryFrom`.

## Why CI didn't catch it

The root `Cargo.toml` is both a `[package]` (`evm`) and a `[workspace]`, with no `default-members`. Per Cargo's rules, commands run from the root then default to the root package only — so `cargo test` (the workflow's only test step) never descends into `evm-core`, and `cargo build` compiles `evm-core` only as a dependency (a dependency's `#[cfg(test)]` modules are never built). `cargo clippy --all` lints lib/bin targets but not test targets.

It surfaces with:

```
cargo check --workspace --tests
```

## Fix

- Pass a `&[u8]` (`bytes.as_slice()`) so the `TryFrom<&[u8]>` impl is selected.
- Compare against `Ok(..)` / `Err(DelegationError::InvalidFormat)`.

Test-only change; no library code is touched.

## Optional follow-up

Adding `--workspace` to the `cargo test` step in `.github/workflows/rust.yml` would catch this whole class of never-compiled test code across `core`/`gasometer`/`runtime`/`fuzzer`.